### PR TITLE
Более удобный переход.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,7 +138,7 @@
 Код примеров опубликован в открытом доступе, поэтому
 Вы можете взять его и начать писать вокруг своё.
 
-Посетите `эту страницу <https://github.com/MarshalX/yandex-music-api/blob/master/examples/README.md>`_
+Посетите `эту страницу <https://github.com/MarshalX/yandex-music-api/blob/master/examples/>`_
 чтобы изучить официальные примеры.
 
 -----------


### PR DESCRIPTION
Нет необходимости указывать путь до MD файла, гитхаб автоматически покажет README вместе со списком файлов в директории.