### PR TITLE
Убран импорт from __future__ import annotations для поддержки Python …

### DIFF
--- a/yandex_music/__init__.py
+++ b/yandex_music/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from .base import YandexMusicObject
 
 from .settings import Settings


### PR DESCRIPTION
…3.6 (всё равно везде в тайпинге используются строки для указания классов)