### PR TITLE
Added `fetch_tracks` shortcut in Playlist

### DIFF
--- a/yandex_music/playlist/playlist.py
+++ b/yandex_music/playlist/playlist.py
@@ -277,3 +277,5 @@ class Playlist(YandexMusicObject):
     downloadAnimatedCover = download_animated_cover
     #: Псевдоним для :attr:`download_og_image`
     downloadOgImage = download_og_image
+    #: Псевдином для :attr:`fetch_tracks`
+    fetchTracks = fetch_tracks

--- a/yandex_music/playlist/playlist.py
+++ b/yandex_music/playlist/playlist.py
@@ -208,6 +208,16 @@ class Playlist(YandexMusicObject):
         """
         return self.client.users_likes_playlists_remove(self.uid, self.client.me.account.uid, *args, **kwargs)
 
+    def fetch_tracks(self, *args, **kwargs) -> List['TrackShort']:
+        """
+            Запрашивает список треков выбранного плейлиста.
+
+            Сокращение для::
+
+                client.users_playlists(playlist.kind, playlist.owner.id, *args, **kwargs)[0].tracks
+        """
+        return self.client.users_playlists(self.kind, self.owner.uid, *args, **kwargs)[0].tracks
+
     @classmethod
     def de_json(cls, data: dict, client: 'Client') -> Optional['Playlist']:
         """Десериализация объекта.


### PR DESCRIPTION
Теперь в `Playlist` можно писать

```
my_playlist.fetch_tracks()
```

чтобы получить список треков через API