### PR TITLE
Исправлены поля landing.blocks и artist.brief_info в документации.

### DIFF
--- a/yandex_music/artist/brief_info.py
+++ b/yandex_music/artist/brief_info.py
@@ -16,7 +16,7 @@ class BriefInfo(YandexMusicObject):
         also_albums (:obj:`list` из :obj:`yandex_music.Album`): Сборники.
         last_release_ids (:obj:`list` из :obj:`int`): Уникальные идентификаторы последних выпущенных треков.
         popular_tracks (:obj:`list` из :obj:`yandex_music.Track`): Популярные треки.
-        similar_artists (:obj:`list` из :obj:`yandex_music.Artist)`: Похожие артисты.
+        similar_artists (:obj:`list` из :obj:`yandex_music.Artist`): Похожие артисты.
         all_covers (:obj:`list` из :obj:`yandex_music.Cover`): Все обложки.
         concerts (:obj:`str`): Концерты (тест-кейс с ними потерялся, мало у кого есть).
         videos (:obj:`list` из :obj:`yandex_music.Video`): Видео.

--- a/yandex_music/landing/landing.py
+++ b/yandex_music/landing/landing.py
@@ -12,7 +12,7 @@ class Landing(YandexMusicObject):
     Attributes:
         pumpkin (:obj:`bool`): Хэллоуин.
         content_id (:obj:`str` | :obj:`int`): Уникальный идентификатор контента.
-        blocks (:obj:`list` из :obj:`yandex_music.Block): Блоки лендинга.
+        blocks (:obj:`list` из :obj:`yandex_music.Block`): Блоки лендинга.
         client (:obj:`yandex_music.Client`): Клиент Yandex Music.
 
     Args:


### PR DESCRIPTION
https://yandex-music.readthedocs.io/ru/latest/yandex_music.landing.landing.html
Поле blocks отображается некорректно.
https://yandex-music.readthedocs.io/ru/latest/yandex_music.artist.brief_info.html
Тип поля similar_artists отображается некорректно.