### PR TITLE
Исправленна проблема с yandex music api в _request_wrapper

### DIFF
--- a/yandex_music/utils/request.py
+++ b/yandex_music/utils/request.py
@@ -206,7 +206,7 @@ class Request:
         if 'CAPTCHA' in message:
             exception = CaptchaWrong if 'Wrong' in message else CaptchaRequired
             raise exception(message, CaptchaResponse.de_json(parse.result, self.client))
-        elif not isinstance(parse.result, dict):
+        elif isinstance(parse.result, str):
             raise NetworkError(f'{parse.result} ({resp.status_code})')
         elif 200 <= resp.status_code <= 299:
             return resp

--- a/yandex_music/utils/request.py
+++ b/yandex_music/utils/request.py
@@ -207,7 +207,6 @@ class Request:
             exception = CaptchaWrong if 'Wrong' in message else CaptchaRequired
             raise exception(message, CaptchaResponse.de_json(parse.result, self.client))
         elif not isinstance(parse.result, dict):
-            print(f'{parse.result} ({resp.status_code})')
             raise NetworkError(f'{parse.result} ({resp.status_code})')
         elif 200 <= resp.status_code <= 299:
             return resp

--- a/yandex_music/utils/response.py
+++ b/yandex_music/utils/response.py
@@ -18,7 +18,7 @@ class Response(YandexMusicObject):
     Attributes:
         data (:obj:`dict`): Ответ на запрос. Используется тогда, когда отсутствует `result`.
         invocation_info (:obj:`yandex_music.InvocationInfo` | :obj:`None`): Информация о запросе.
-        result (:obj:`dict`): Ответ на запрос (секция с результатом).
+        result (:obj:`dict`, `list`, `str`): Ответ на запрос (секция с результатом).
         error (:obj:`str`): Код ошибки.
         error_description (:obj:`str`): Описание ошибки.
         client (:obj:`yandex_music.Client`): Клиент Yandex Music.
@@ -37,7 +37,7 @@ class Response(YandexMusicObject):
         self,
         data: dict,
         invocation_info: Optional['InvocationInfo'] = None,
-        result: Union[dict, str] = None,
+        result: Union[dict, list, str] = None,
         error: str = None,
         error_description: str = None,
         client: Optional['Client'] = None,

--- a/yandex_music/utils/response.py
+++ b/yandex_music/utils/response.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from yandex_music import YandexMusicObject
 
@@ -37,7 +37,7 @@ class Response(YandexMusicObject):
         self,
         data: dict,
         invocation_info: Optional['InvocationInfo'] = None,
-        result: dict = None,
+        result: Union[dict, str] = None,
         error: str = None,
         error_description: str = None,
         client: Optional['Client'] = None,


### PR DESCRIPTION
Суть проблемы: Сервис api может вернуть сигнал 200, даже если произошла ошибка при выдочи результата.
Если указать в метод `client.search` `text`, который состоит из пробелов, или вообще пустой, то будет вызываться исключение:
```
Traceback (most recent call last):
  File ".../tests/test_search.py", line 49, in test_yandex_music_search
    self._test_service(ServicesSearch.yandex_music_search)
  File ".../tests/test_search.py", line 32, in _test_service
    result = search_func(query=query, limit=limit)
  File ".../utils/search.py", line 191, in yandex_music_search
    search = yandex_music_client.search(query) # Делаем поисковой запрос
  File ".../venv/lib/python3.9/site-packages/yandex_music/client.py", line 72, in wrapper
    result = method(*args, **kwargs)
  File ".../venv/lib/python3.9/site-packages/yandex_music/client.py", line 919, in search
    return Search.de_json(result, self)
  File ".../venv/lib/python3.9/site-packages/yandex_music/search/search.py", line 157, in de_json
    data = super(Search, cls).de_json(data, client)
  File ".../venv/lib/python3.9/site-packages/yandex_music/base.py", line 64, in de_json
    data = data.copy()
AttributeError: 'str' object has no attribute 'copy'
```
Я исправил проблему, проверяя класс `result`