### PR TITLE
Сделал поле uri класса Description опциональным

### DIFF
--- a/tests/test_description.py
+++ b/tests/test_description.py
@@ -17,11 +17,10 @@ class TestDescription:
         assert Description.de_json({}, client) is None
 
     def test_de_json_required(self, client):
-        json_dict = {'text': self.text, 'uri': self.uri}
+        json_dict = {'text': self.text}
         description = Description.de_json(json_dict, client)
 
         assert description.text == self.text
-        assert description.uri == self.uri
 
     def test_de_json_all(self, client):
         json_dict = {'text': self.text, 'uri': self.uri}

--- a/yandex_music/artist/description.py
+++ b/yandex_music/artist/description.py
@@ -17,12 +17,12 @@ class Description(YandexMusicModel):
 
     Attributes:
         text (:obj:`str`): Описание исполнителя.
-        uri (:obj:`str`): Ссылка на источник.
+        uri (:obj:`str`, optional): Ссылка на источник.
         client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
     """
 
     text: str
-    uri: str
+    uri: Optional[str] = None
     client: Optional['ClientType'] = None
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
Столкнулся с проблемой, что некоторые исполнители не имеют данного поля из-за чего происходит ошибка
`TypeError: Description.__init__() missing 1 required positional argument: 'uri'