### PR TITLE
Make `id` field within `Artist` optional

### DIFF
--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -1,3 +1,5 @@
+import pytest
+
 from yandex_music import Artist
 
 
@@ -70,10 +72,14 @@ class TestArtist:
         assert Artist.de_list([], client) == []
 
     def test_de_json_required(self, client, cover):
-        json_dict = {'id': self.id}
-        artist = Artist.de_json(json_dict, client)
+        # We don't have any required fields anymore,
+        #   so just make sure we don't throw any errors.
+        Artist.de_json({}, client)
 
-        assert artist.id == self.id
+    def test_de_json_ugc(self, client):
+        # An example of UGC artist from #663
+        artist = Artist.de_json({'name': self.name}, client)
+        assert artist.name == self.name
 
     def test_de_json_all(
         self, client, cover, counts, ratings, link, track_without_artists, description, artist_decomposed
@@ -154,3 +160,10 @@ class TestArtist:
         assert a is not b
 
         assert a == c
+
+    def test_id_required(self, client):
+        artist = Artist.de_json({'name': self.name}, client)
+
+        # Make sure we throw an error if we try to access the id_required property when id is None
+        with pytest.raises(ValueError):
+            _ = artist.id_required

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -1,6 +1,7 @@
 import pytest
 
 from yandex_music import Artist
+from yandex_music.exceptions import IDMissingError
 
 
 class TestArtist:
@@ -165,5 +166,5 @@ class TestArtist:
         artist = Artist.de_json({'name': self.name}, client)
 
         # Make sure we throw an error if we try to access the id_required property when id is None
-        with pytest.raises(ValueError):
+        with pytest.raises(IDMissingError):
             _ = artist.id_required

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -1,7 +1,7 @@
 import pytest
 
 from yandex_music import Artist
-from yandex_music.exceptions import IDMissingError
+from yandex_music.exceptions import IdMissingError
 
 
 class TestArtist:
@@ -166,5 +166,5 @@ class TestArtist:
         artist = Artist.de_json({'name': self.name}, client)
 
         # Make sure we throw an error if we try to access the id_required property when id is None
-        with pytest.raises(IDMissingError):
+        with pytest.raises(IdMissingError):
             _ = artist.id_required

--- a/yandex_music/artist/artist.py
+++ b/yandex_music/artist/artist.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from yandex_music import YandexMusicModel
-from yandex_music.exceptions import IDMissingError
+from yandex_music.exceptions import IdMissingError
 from yandex_music.utils import model
 
 if TYPE_CHECKING:
@@ -98,13 +98,13 @@ class Artist(YandexMusicModel):
         """Возвращает ID исполнителя, удостоверяясь, что он указан.
 
         Raises:
-            ValueError: Если ID исполнителя не установлен.
+            IdMissingError: Если ID исполнителя не установлен.
 
         Returns:
             :obj:`int`: Уникальный идентификатор исполнителя.
         """
         if self.id is None:
-            raise IDMissingError('Artist.id is required')
+            raise IdMissingError('Artist.id is required')
 
         return self.id
 

--- a/yandex_music/artist/artist.py
+++ b/yandex_music/artist/artist.py
@@ -23,7 +23,7 @@ class Artist(YandexMusicModel):
     """Класс, представляющий исполнителя.
 
     Attributes:
-        id (:obj:`int`): Уникальный идентификатор.
+        id (:obj:`int`, optional): Уникальный идентификатор.
         error (:obj:`str`, optional): Сообщение об ошибке с объяснением почему не вернуло исполнителя.
         reason (:obj:`str`, optional): Причина отсутствия исполнителя (сообщение об ошибке).
         name (:obj:`str`, optional): Название.
@@ -57,7 +57,7 @@ class Artist(YandexMusicModel):
         client (:obj:`yandex_music.Client`): Клиент Yandex Music.
     """
 
-    id: int
+    id: Optional[int] = None
     error: Optional[str] = None
     reason: Optional[str] = None
     name: Optional[str] = None

--- a/yandex_music/artist/artist.py
+++ b/yandex_music/artist/artist.py
@@ -92,6 +92,22 @@ class Artist(YandexMusicModel):
     def __post_init__(self) -> None:
         self._id_attrs = (self.id, self.name, self.cover)
 
+    @property
+    def id_required(self) -> int:
+        """Возвращает ID исполнителя, удостоверяясь, что он указан.
+
+        Raises:
+            ValueError: Если ID исполнителя не установлен.
+
+        Returns:
+            :obj:`int`: Уникальный идентификатор исполнителя.
+        """
+        if self.id is None:
+            msg = 'Artist.id is required'
+            raise ValueError(msg)
+
+        return self.id
+
     def get_op_image_url(self, size: str = '200x200') -> str:
         """Возвращает URL OP обложки.
 
@@ -222,7 +238,7 @@ class Artist(YandexMusicModel):
         client.users_likes_artists_add(artist.id, user.id *args, **kwargs)
         """
         assert self.valid_client(self.client)
-        return self.client.users_likes_artists_add(self.id, self.client.account_uid, *args, **kwargs)
+        return self.client.users_likes_artists_add(self.id_required, self.client.account_uid, *args, **kwargs)
 
     async def like_async(self, *args: Any, **kwargs: Any) -> bool:
         """Сокращение для::
@@ -230,7 +246,7 @@ class Artist(YandexMusicModel):
         await client.users_likes_artists_add(artist.id, user.id *args, **kwargs)
         """
         assert self.valid_async_client(self.client)
-        return await self.client.users_likes_artists_add(self.id, self.client.account_uid, *args, **kwargs)
+        return await self.client.users_likes_artists_add(self.id_required, self.client.account_uid, *args, **kwargs)
 
     def dislike(self, *args: Any, **kwargs: Any) -> bool:
         """Сокращение для::
@@ -238,7 +254,7 @@ class Artist(YandexMusicModel):
         client.users_likes_artists_remove(artist.id, user.id *args, **kwargs)
         """
         assert self.valid_client(self.client)
-        return self.client.users_likes_artists_remove(self.id, self.client.account_uid, *args, **kwargs)
+        return self.client.users_likes_artists_remove(self.id_required, self.client.account_uid, *args, **kwargs)
 
     async def dislike_async(self, *args: Any, **kwargs: Any) -> bool:
         """Сокращение для::
@@ -246,7 +262,7 @@ class Artist(YandexMusicModel):
         await client.users_likes_artists_remove(artist.id, user.id *args, **kwargs)
         """
         assert self.valid_async_client(self.client)
-        return await self.client.users_likes_artists_remove(self.id, self.client.account_uid, *args, **kwargs)
+        return await self.client.users_likes_artists_remove(self.id_required, self.client.account_uid, *args, **kwargs)
 
     def get_tracks(self, page: int = 0, page_size: int = 20, *args: Any, **kwargs: Any) -> Optional['ArtistTracks']:
         """Сокращение для::
@@ -254,7 +270,7 @@ class Artist(YandexMusicModel):
         client.artists_tracks(artist.id, page, page_size, *args, **kwargs)
         """
         assert self.valid_client(self.client)
-        return self.client.artists_tracks(self.id, page, page_size, *args, **kwargs)
+        return self.client.artists_tracks(self.id_required, page, page_size, *args, **kwargs)
 
     async def get_tracks_async(
         self, page: int = 0, page_size: int = 20, *args: Any, **kwargs: Any
@@ -264,7 +280,7 @@ class Artist(YandexMusicModel):
         await client.artists_tracks(artist.id, page, page_size, *args, **kwargs)
         """
         assert self.valid_async_client(self.client)
-        return await self.client.artists_tracks(self.id, page, page_size, *args, **kwargs)
+        return await self.client.artists_tracks(self.id_required, page, page_size, *args, **kwargs)
 
     def get_albums(
         self, page: int = 0, page_size: int = 20, sort_by: str = 'year', *args: Any, **kwargs: Any
@@ -274,7 +290,7 @@ class Artist(YandexMusicModel):
         client.artists_direct_albums(artist.id, page, page_size, sort_by, *args, **kwargs)
         """
         assert self.valid_client(self.client)
-        return self.client.artists_direct_albums(self.id, page, page_size, sort_by, *args, **kwargs)
+        return self.client.artists_direct_albums(self.id_required, page, page_size, sort_by, *args, **kwargs)
 
     async def get_albums_async(
         self, page: int = 0, page_size: int = 20, sort_by: str = 'year', *args: Any, **kwargs: Any
@@ -284,7 +300,7 @@ class Artist(YandexMusicModel):
         await client.artists_direct_albums(artist.id, page, page_size, sort_by, *args, **kwargs)
         """
         assert self.valid_async_client(self.client)
-        return await self.client.artists_direct_albums(self.id, page, page_size, sort_by, *args, **kwargs)
+        return await self.client.artists_direct_albums(self.id_required, page, page_size, sort_by, *args, **kwargs)
 
     @classmethod
     def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['Artist']:

--- a/yandex_music/artist/artist.py
+++ b/yandex_music/artist/artist.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from yandex_music import YandexMusicModel
+from yandex_music.exceptions import IDMissingError
 from yandex_music.utils import model
 
 if TYPE_CHECKING:
@@ -103,8 +104,7 @@ class Artist(YandexMusicModel):
             :obj:`int`: Уникальный идентификатор исполнителя.
         """
         if self.id is None:
-            msg = 'Artist.id is required'
-            raise ValueError(msg)
+            raise IDMissingError('Artist.id is required')
 
         return self.id
 
@@ -235,7 +235,7 @@ class Artist(YandexMusicModel):
     def like(self, *args: Any, **kwargs: Any) -> bool:
         """Сокращение для::
 
-        client.users_likes_artists_add(artist.id, user.id *args, **kwargs)
+        client.users_likes_artists_add(artist.id_required, user.id *args, **kwargs)
         """
         assert self.valid_client(self.client)
         return self.client.users_likes_artists_add(self.id_required, self.client.account_uid, *args, **kwargs)
@@ -243,7 +243,7 @@ class Artist(YandexMusicModel):
     async def like_async(self, *args: Any, **kwargs: Any) -> bool:
         """Сокращение для::
 
-        await client.users_likes_artists_add(artist.id, user.id *args, **kwargs)
+        await client.users_likes_artists_add(artist.id_required, user.id *args, **kwargs)
         """
         assert self.valid_async_client(self.client)
         return await self.client.users_likes_artists_add(self.id_required, self.client.account_uid, *args, **kwargs)
@@ -251,7 +251,7 @@ class Artist(YandexMusicModel):
     def dislike(self, *args: Any, **kwargs: Any) -> bool:
         """Сокращение для::
 
-        client.users_likes_artists_remove(artist.id, user.id *args, **kwargs)
+        client.users_likes_artists_remove(artist.id_required, user.id *args, **kwargs)
         """
         assert self.valid_client(self.client)
         return self.client.users_likes_artists_remove(self.id_required, self.client.account_uid, *args, **kwargs)
@@ -259,7 +259,7 @@ class Artist(YandexMusicModel):
     async def dislike_async(self, *args: Any, **kwargs: Any) -> bool:
         """Сокращение для::
 
-        await client.users_likes_artists_remove(artist.id, user.id *args, **kwargs)
+        await client.users_likes_artists_remove(artist.id_required, user.id *args, **kwargs)
         """
         assert self.valid_async_client(self.client)
         return await self.client.users_likes_artists_remove(self.id_required, self.client.account_uid, *args, **kwargs)
@@ -267,7 +267,7 @@ class Artist(YandexMusicModel):
     def get_tracks(self, page: int = 0, page_size: int = 20, *args: Any, **kwargs: Any) -> Optional['ArtistTracks']:
         """Сокращение для::
 
-        client.artists_tracks(artist.id, page, page_size, *args, **kwargs)
+        client.artists_tracks(artist.id_required, page, page_size, *args, **kwargs)
         """
         assert self.valid_client(self.client)
         return self.client.artists_tracks(self.id_required, page, page_size, *args, **kwargs)
@@ -277,7 +277,7 @@ class Artist(YandexMusicModel):
     ) -> Optional['ArtistTracks']:
         """Сокращение для::
 
-        await client.artists_tracks(artist.id, page, page_size, *args, **kwargs)
+        await client.artists_tracks(artist.id_required, page, page_size, *args, **kwargs)
         """
         assert self.valid_async_client(self.client)
         return await self.client.artists_tracks(self.id_required, page, page_size, *args, **kwargs)
@@ -287,7 +287,7 @@ class Artist(YandexMusicModel):
     ) -> Optional['ArtistAlbums']:
         """Сокращение для::
 
-        client.artists_direct_albums(artist.id, page, page_size, sort_by, *args, **kwargs)
+        client.artists_direct_albums(artist.id_required, page, page_size, sort_by, *args, **kwargs)
         """
         assert self.valid_client(self.client)
         return self.client.artists_direct_albums(self.id_required, page, page_size, sort_by, *args, **kwargs)
@@ -297,7 +297,7 @@ class Artist(YandexMusicModel):
     ) -> Optional['ArtistAlbums']:
         """Сокращение для::
 
-        await client.artists_direct_albums(artist.id, page, page_size, sort_by, *args, **kwargs)
+        await client.artists_direct_albums(artist.id_required, page, page_size, sort_by, *args, **kwargs)
         """
         assert self.valid_async_client(self.client)
         return await self.client.artists_direct_albums(self.id_required, page, page_size, sort_by, *args, **kwargs)
@@ -344,6 +344,8 @@ class Artist(YandexMusicModel):
 
     # camelCase псевдонимы
 
+    #: Псевдоним для :attr:`id_required`
+    idRequired = id_required
     #: Псевдоним для :attr:`get_op_image_url`
     getOpImageUrl = get_op_image_url
     #: Псевдоним для :attr:`get_og_image_url`

--- a/yandex_music/exceptions.py
+++ b/yandex_music/exceptions.py
@@ -12,7 +12,7 @@ class InvalidBitrateError(YandexMusicError):
     """Класс исключения, вызываемого при попытке загрузки трека с недоступным битрейтом."""
 
 
-class IDMissingError(YandexMusicError):
+class IdMissingError(YandexMusicError):
     """Класс исключения, вызываемого при попытке использования отсутствующего ID."""
 
 

--- a/yandex_music/exceptions.py
+++ b/yandex_music/exceptions.py
@@ -12,6 +12,10 @@ class InvalidBitrateError(YandexMusicError):
     """Класс исключения, вызываемого при попытке загрузки трека с недоступным битрейтом."""
 
 
+class IDMissingError(YandexMusicError):
+    """Класс исключения, вызываемого при попытке использования отсутствующего ID."""
+
+
 class NetworkError(YandexMusicError):
     """Базовый класс исключений, вызываемых для ошибок, связанных с запросами к серверу."""
 


### PR DESCRIPTION
Resolves #662

From now on, for all local tracks (UGC) yandex doesn't generate any IDs for artists. 

For UGC tracks artist object would look like this:
```json
{
    "name": "Name here"
}
```

All the other fields, including ID are ignored.