### PR TITLE
Исправлены аннотации типов в миксинах клиента

### DIFF
--- a/yandex_music/_client/__init__.py
+++ b/yandex_music/_client/__init__.py
@@ -4,7 +4,7 @@
 
 import functools
 import logging
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, cast
 
 F = TypeVar('F', bound=Callable[..., Any])
 
@@ -14,7 +14,7 @@ def log(method: F) -> F:
     logger = logging.getLogger(method.__module__)
 
     @functools.wraps(method)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401:
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         logger.debug(f'Entering: {method.__name__}')
 
         result = method(*args, **kwargs)
@@ -24,4 +24,4 @@ def log(method: F) -> F:
 
         return result
 
-    return wrapper
+    return cast('F', wrapper)

--- a/yandex_music/_client/account.py
+++ b/yandex_music/_client/account.py
@@ -2,7 +2,7 @@
 # THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/account.py. DON'T EDIT IT BY HANDS #
 ################################################################################################
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from typing_extensions import Self
 
@@ -11,7 +11,6 @@ from yandex_music._client import log
 from yandex_music._client_base import ClientBase
 
 if TYPE_CHECKING:
-    from yandex_music.base import JSONType
     from yandex_music.utils.request import Request
 
 
@@ -85,7 +84,7 @@ class AccountMixin(ClientBase):
         self,
         param: Optional[str] = None,
         value: Optional[Union[str, int, bool]] = None,
-        data: Optional['JSONType'] = None,
+        data: Optional[Dict[str, Any]] = None,
         *args: Any,
         **kwargs: Any,
     ) -> Optional[UserSettings]:

--- a/yandex_music/_client/batch.py
+++ b/yandex_music/_client/batch.py
@@ -2,14 +2,15 @@
 # THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/batch.py. DON'T EDIT IT BY HANDS #
 ##############################################################################################
 
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union, overload
+
+from typing_extensions import Literal
 
 from yandex_music import Album, Artist, Playlist, Track
 from yandex_music._client import log
 from yandex_music._client_base import ClientBase, de_list
 
 if TYPE_CHECKING:
-    from yandex_music.base import JSONType
     from yandex_music.utils.request import Request
 
 
@@ -18,14 +19,54 @@ class BatchMixin(ClientBase):
 
     _request: 'Request'
 
+    @overload
+    def _get_list(
+        self,
+        object_type: Literal['artist'],
+        ids: Union[Sequence[Union[str, int]], int, str],
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Artist]: ...
+
+    @overload
+    def _get_list(
+        self,
+        object_type: Literal['album'],
+        ids: Union[Sequence[Union[str, int]], int, str],
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Album]: ...
+
+    @overload
+    def _get_list(
+        self,
+        object_type: Literal['track'],
+        ids: Union[Sequence[Union[str, int]], int, str],
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Track]: ...
+
+    @overload
+    def _get_list(
+        self,
+        object_type: Literal['playlist'],
+        ids: Union[Sequence[Union[str, int]], int, str],
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Playlist]: ...
+
     def _get_list(
         self,
         object_type: str,
-        ids: Union[List[Union[str, int]], int, str],
-        params: Optional['JSONType'] = None,
+        ids: Union[Sequence[Union[str, int]], int, str],
+        params: Optional[Dict[str, Any]] = None,
         *args: Any,
         **kwargs: Any,
-    ) -> List[Union[Artist, Album, Track, Playlist]]:
+    ) -> list:
         """Получение объекта/объектов.
 
         Args:
@@ -52,7 +93,7 @@ class BatchMixin(ClientBase):
 
         result = self._request.post(url, params, *args, **kwargs)
 
-        return de_list[object_type](result, self)
+        return list(de_list[object_type](result, self))
 
     @log
     def artists(self, artist_ids: Union[List[Union[str, int]], int, str], *args: Any, **kwargs: Any) -> List[Artist]:
@@ -93,7 +134,7 @@ class BatchMixin(ClientBase):
     @log
     def tracks(
         self,
-        track_ids: Union[List[str], List[int], List[Union[str, int]], int, str],
+        track_ids: Union[Sequence[Union[str, int]], int, str],
         with_positions: bool = True,
         *args: Any,
         **kwargs: Any,

--- a/yandex_music/_client/landing.py
+++ b/yandex_music/_client/landing.py
@@ -2,14 +2,13 @@
 # THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/landing.py. DON'T EDIT IT BY HANDS #
 ################################################################################################
 
-from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from yandex_music import ChartInfo, Feed, Genre, Landing, LandingList, TagResult
 from yandex_music._client import log
-from yandex_music._client_base import ClientBase
+from yandex_music._client_base import ClientBase, is_dict
 
 if TYPE_CHECKING:
-    from yandex_music.base import JSONType
     from yandex_music.utils.request import Request
 
 
@@ -56,7 +55,9 @@ class LandingMixin(ClientBase):
 
         result = self._request.get(url, *args, **kwargs)
 
-        return result.get('isWizardPassed') or False
+        if is_dict(result):
+            return bool(result.get('isWizardPassed'))
+        return False
 
     @log
     def landing(self, blocks: Union[str, List[str]], *args: Any, **kwargs: Any) -> Optional[Landing]:
@@ -78,7 +79,7 @@ class LandingMixin(ClientBase):
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
         """
         url = f'{self.base_url}/landing3'
-        params = cast('JSONType', {'blocks': blocks, 'eitherUserId': '10254713668400548221'})
+        params: Dict[str, Any] = {'blocks': blocks, 'eitherUserId': '10254713668400548221'}
 
         result = self._request.get(url, params, *args, **kwargs)
         # TODO (MarshalX) что тут делает константа с чьим-то User ID
@@ -192,7 +193,7 @@ class LandingMixin(ClientBase):
 
         result = self._request.get(url, *args, **kwargs)
 
-        return Genre.de_list(result, self)
+        return list(Genre.de_list(result, self))
 
     @log
     def tags(self, tag_id: str, *args: Any, **kwargs: Any) -> Optional[TagResult]:

--- a/yandex_music/_client/likes.py
+++ b/yandex_music/_client/likes.py
@@ -2,14 +2,15 @@
 # THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/likes.py. DON'T EDIT IT BY HANDS #
 ##############################################################################################
 
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, overload
+
+from typing_extensions import Literal
 
 from yandex_music import Like, TracksList
 from yandex_music._client import log
-from yandex_music._client_base import ClientBase, UserIdType
+from yandex_music._client_base import ClientBase, UserIdType, is_dict
 
 if TYPE_CHECKING:
-    from yandex_music.base import JSONType
     from yandex_music.utils.request import Request
 
 
@@ -60,7 +61,7 @@ class LikesMixin(ClientBase):
         result = self._request.post(url, {f'{object_type}-ids': ids}, *args, **kwargs)
 
         if object_type == 'track':
-            return 'revision' in result
+            return is_dict(result) and 'revision' in result
 
         return result == 'ok'
 
@@ -275,11 +276,31 @@ class LikesMixin(ClientBase):
         """
         return self._like_action('album', album_ids, remove=True, user_id=user_id, **kwargs)
 
+    @overload
+    def _get_likes(
+        self,
+        object_type: Literal['track'],
+        user_id: UserIdType = ...,
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[TracksList]: ...
+
+    @overload
+    def _get_likes(
+        self,
+        object_type: Literal['album', 'artist', 'playlist'],
+        user_id: UserIdType = ...,
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Like]: ...
+
     def _get_likes(
         self,
         object_type: str,
         user_id: UserIdType = None,
-        params: Optional['JSONType'] = None,
+        params: Optional[Dict[str, Any]] = None,
         *args: Any,
         **kwargs: Any,
     ) -> Union[List[Like], Optional[TracksList]]:
@@ -307,9 +328,11 @@ class LikesMixin(ClientBase):
         result = self._request.get(url, params, *args, **kwargs)
 
         if object_type == 'track':
-            return TracksList.de_json(result.get('library'), self)
+            if is_dict(result):
+                return TracksList.de_json(result.get('library'), self)
+            return None
 
-        return Like.de_list(result, self, object_type)
+        return list(Like.de_list(result, self, object_type))
 
     @log
     def users_likes_tracks(
@@ -432,7 +455,9 @@ class LikesMixin(ClientBase):
 
         result = self._request.get(url, {'if_modified_since_revision': if_modified_since_revision}, *args, **kwargs)
 
-        return TracksList.de_json(result.get('library'), self)
+        if is_dict(result):
+            return TracksList.de_json(result.get('library'), self)
+        return None
 
     def _dislike_action(
         self,
@@ -467,7 +492,7 @@ class LikesMixin(ClientBase):
 
         result = self._request.post(url, {'track-ids': ids}, *args, **kwargs)
 
-        return 'revision' in result
+        return is_dict(result) and 'revision' in result
 
     @log
     def users_dislikes_tracks_add(

--- a/yandex_music/_client/playlists.py
+++ b/yandex_music/_client/playlists.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from yandex_music import Playlist, PlaylistRecommendations, UserSettings
 from yandex_music._client import log
-from yandex_music._client_base import ClientBase, UserIdType
+from yandex_music._client_base import ClientBase, UserIdType, is_dict
 from yandex_music.utils.difference import Difference
 
 if TYPE_CHECKING:
@@ -44,7 +44,9 @@ class PlaylistsMixin(ClientBase):
 
         result = self._request.get(url, *args, **kwargs)
 
-        return UserSettings.de_json(result.get('userSettings'), self)
+        if is_dict(result):
+            return UserSettings.de_json(result.get('userSettings'), self)
+        return None
 
     @log
     def users_playlists(
@@ -82,7 +84,7 @@ class PlaylistsMixin(ClientBase):
             data = {'kinds': kind}
 
             result = self._request.post(url, data, *args, **kwargs)
-            return Playlist.de_list(result, self)
+            return list(Playlist.de_list(result, self))
 
         url = f'{self.base_url}/users/{user_id}/playlists/{kind}'
         result = self._request.get(url, *args, **kwargs)
@@ -418,7 +420,7 @@ class PlaylistsMixin(ClientBase):
 
         result = self._request.get(url, *args, **kwargs)
 
-        return Playlist.de_list(result, self)
+        return list(Playlist.de_list(result, self))
 
     # camelCase псевдонимы
 

--- a/yandex_music/_client/queue.py
+++ b/yandex_music/_client/queue.py
@@ -2,11 +2,11 @@
 # THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/queue.py. DON'T EDIT IT BY HANDS #
 ##############################################################################################
 
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 from yandex_music import Queue, QueueItem
 from yandex_music._client import log
-from yandex_music._client_base import ClientBase
+from yandex_music._client_base import ClientBase, is_dict
 
 if TYPE_CHECKING:
     from yandex_music.utils.request import Request
@@ -46,7 +46,9 @@ class QueueMixin(ClientBase):
         self._request.headers['X-Yandex-Music-Device'] = device
         result = self._request.get(url, *args, **kwargs)
 
-        return QueueItem.de_list(result.get('queues'), self)
+        if is_dict(result):
+            return list(QueueItem.de_list(result.get('queues'), self))
+        return []
 
     @log
     def queue(self, queue_id: str, *args: Any, **kwargs: Any) -> Optional[Queue]:
@@ -97,7 +99,7 @@ class QueueMixin(ClientBase):
         self._request.headers['X-Yandex-Music-Device'] = device
         result = self._request.post(url, {'isInteractive': False}, params={'currentIndex': current_index}, **kwargs)
 
-        return result.get('status') == 'ok'
+        return is_dict(result) and result.get('status') == 'ok'
 
     @log
     def queue_create(
@@ -128,7 +130,9 @@ class QueueMixin(ClientBase):
         self._request.headers['X-Yandex-Music-Device'] = device
         result = self._request.post(url, queue, *args, **kwargs)
 
-        return result.get('id')
+        if is_dict(result):
+            return cast('Optional[str]', result.get('id'))
+        return None
 
     # camelCase псевдонимы
 

--- a/yandex_music/_client/radio.py
+++ b/yandex_music/_client/radio.py
@@ -90,7 +90,7 @@ class RadioMixin(ClientBase):
 
         result = self._request.get(url, {'language': language}, *args, **kwargs)
 
-        return StationResult.de_list(result, self)
+        return list(StationResult.de_list(result, self))
 
     @log
     def rotor_station_feedback(
@@ -283,7 +283,7 @@ class RadioMixin(ClientBase):
 
         result = self._request.get(url, *args, **kwargs)
 
-        return StationResult.de_list(result, self)
+        return list(StationResult.de_list(result, self))
 
     @log
     def rotor_station_settings2(

--- a/yandex_music/_client/tracks.py
+++ b/yandex_music/_client/tracks.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from yandex_music import Album, DownloadInfo, ShotEvent, SimilarTracks, Supplement, TrackLyrics
 from yandex_music._client import log
-from yandex_music._client_base import ClientBase
+from yandex_music._client_base import ClientBase, is_dict
 from yandex_music.utils.sign_request import get_sign_request
 
 if TYPE_CHECKING:
@@ -279,7 +279,9 @@ class TracksMixin(ClientBase):
 
         # TODO (MarshalX) судя по всему ручка ещё возвращает рекламу после треков для пользователей без подписки.
         #  https://github.com/MarshalX/yandex-music-api/issues/557
-        return ShotEvent.de_json(result.get('shotEvent'), self)
+        if is_dict(result):
+            return ShotEvent.de_json(result.get('shotEvent'), self)
+        return None
 
     # camelCase псевдонимы
 

--- a/yandex_music/_client_async/__init__.py
+++ b/yandex_music/_client_async/__init__.py
@@ -1,6 +1,6 @@
 import functools
 import logging
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, cast
 
 F = TypeVar('F', bound=Callable[..., Any])
 
@@ -10,7 +10,7 @@ def log(method: F) -> F:
     logger = logging.getLogger(method.__module__)
 
     @functools.wraps(method)
-    async def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401:
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
         logger.debug(f'Entering: {method.__name__}')
 
         result = await method(*args, **kwargs)
@@ -20,4 +20,4 @@ def log(method: F) -> F:
 
         return result
 
-    return wrapper
+    return cast('F', wrapper)

--- a/yandex_music/_client_async/account.py
+++ b/yandex_music/_client_async/account.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from typing_extensions import Self
 
@@ -7,7 +7,6 @@ from yandex_music._client_async import log
 from yandex_music._client_base import ClientBase
 
 if TYPE_CHECKING:
-    from yandex_music.base import JSONType
     from yandex_music.utils.request_async import Request
 
 
@@ -81,7 +80,7 @@ class AccountMixin(ClientBase):
         self,
         param: Optional[str] = None,
         value: Optional[Union[str, int, bool]] = None,
-        data: Optional['JSONType'] = None,
+        data: Optional[Dict[str, Any]] = None,
         *args: Any,
         **kwargs: Any,
     ) -> Optional[UserSettings]:

--- a/yandex_music/_client_async/batch.py
+++ b/yandex_music/_client_async/batch.py
@@ -1,11 +1,12 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union, overload
+
+from typing_extensions import Literal
 
 from yandex_music import Album, Artist, Playlist, Track
 from yandex_music._client_async import log
 from yandex_music._client_base import ClientBase, de_list
 
 if TYPE_CHECKING:
-    from yandex_music.base import JSONType
     from yandex_music.utils.request_async import Request
 
 
@@ -14,14 +15,54 @@ class BatchMixin(ClientBase):
 
     _request: 'Request'
 
+    @overload
+    async def _get_list(
+        self,
+        object_type: Literal['artist'],
+        ids: Union[Sequence[Union[str, int]], int, str],
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Artist]: ...
+
+    @overload
+    async def _get_list(
+        self,
+        object_type: Literal['album'],
+        ids: Union[Sequence[Union[str, int]], int, str],
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Album]: ...
+
+    @overload
+    async def _get_list(
+        self,
+        object_type: Literal['track'],
+        ids: Union[Sequence[Union[str, int]], int, str],
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Track]: ...
+
+    @overload
+    async def _get_list(
+        self,
+        object_type: Literal['playlist'],
+        ids: Union[Sequence[Union[str, int]], int, str],
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Playlist]: ...
+
     async def _get_list(
         self,
         object_type: str,
-        ids: Union[List[Union[str, int]], int, str],
-        params: Optional['JSONType'] = None,
+        ids: Union[Sequence[Union[str, int]], int, str],
+        params: Optional[Dict[str, Any]] = None,
         *args: Any,
         **kwargs: Any,
-    ) -> List[Union[Artist, Album, Track, Playlist]]:
+    ) -> list:
         """Получение объекта/объектов.
 
         Args:
@@ -48,7 +89,7 @@ class BatchMixin(ClientBase):
 
         result = await self._request.post(url, params, *args, **kwargs)
 
-        return de_list[object_type](result, self)
+        return list(de_list[object_type](result, self))
 
     @log
     async def artists(
@@ -91,7 +132,7 @@ class BatchMixin(ClientBase):
     @log
     async def tracks(
         self,
-        track_ids: Union[List[str], List[int], List[Union[str, int]], int, str],
+        track_ids: Union[Sequence[Union[str, int]], int, str],
         with_positions: bool = True,
         *args: Any,
         **kwargs: Any,

--- a/yandex_music/_client_async/landing.py
+++ b/yandex_music/_client_async/landing.py
@@ -1,11 +1,10 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from yandex_music import ChartInfo, Feed, Genre, Landing, LandingList, TagResult
 from yandex_music._client_async import log
-from yandex_music._client_base import ClientBase
+from yandex_music._client_base import ClientBase, is_dict
 
 if TYPE_CHECKING:
-    from yandex_music.base import JSONType
     from yandex_music.utils.request_async import Request
 
 
@@ -52,7 +51,9 @@ class LandingMixin(ClientBase):
 
         result = await self._request.get(url, *args, **kwargs)
 
-        return result.get('isWizardPassed') or False
+        if is_dict(result):
+            return bool(result.get('isWizardPassed'))
+        return False
 
     @log
     async def landing(self, blocks: Union[str, List[str]], *args: Any, **kwargs: Any) -> Optional[Landing]:
@@ -74,7 +75,7 @@ class LandingMixin(ClientBase):
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
         """
         url = f'{self.base_url}/landing3'
-        params = cast('JSONType', {'blocks': blocks, 'eitherUserId': '10254713668400548221'})
+        params: Dict[str, Any] = {'blocks': blocks, 'eitherUserId': '10254713668400548221'}
 
         result = await self._request.get(url, params, *args, **kwargs)
         # TODO (MarshalX) что тут делает константа с чьим-то User ID
@@ -188,7 +189,7 @@ class LandingMixin(ClientBase):
 
         result = await self._request.get(url, *args, **kwargs)
 
-        return Genre.de_list(result, self)
+        return list(Genre.de_list(result, self))
 
     @log
     async def tags(self, tag_id: str, *args: Any, **kwargs: Any) -> Optional[TagResult]:

--- a/yandex_music/_client_async/likes.py
+++ b/yandex_music/_client_async/likes.py
@@ -1,11 +1,12 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, overload
+
+from typing_extensions import Literal
 
 from yandex_music import Like, TracksList
 from yandex_music._client_async import log
-from yandex_music._client_base import ClientBase, UserIdType
+from yandex_music._client_base import ClientBase, UserIdType, is_dict
 
 if TYPE_CHECKING:
-    from yandex_music.base import JSONType
     from yandex_music.utils.request_async import Request
 
 
@@ -56,7 +57,7 @@ class LikesMixin(ClientBase):
         result = await self._request.post(url, {f'{object_type}-ids': ids}, *args, **kwargs)
 
         if object_type == 'track':
-            return 'revision' in result
+            return is_dict(result) and 'revision' in result
 
         return result == 'ok'
 
@@ -271,11 +272,31 @@ class LikesMixin(ClientBase):
         """
         return await self._like_action('album', album_ids, remove=True, user_id=user_id, **kwargs)
 
+    @overload
+    async def _get_likes(
+        self,
+        object_type: Literal['track'],
+        user_id: UserIdType = ...,
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[TracksList]: ...
+
+    @overload
+    async def _get_likes(
+        self,
+        object_type: Literal['album', 'artist', 'playlist'],
+        user_id: UserIdType = ...,
+        params: Optional[Dict[str, Any]] = ...,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Like]: ...
+
     async def _get_likes(
         self,
         object_type: str,
         user_id: UserIdType = None,
-        params: Optional['JSONType'] = None,
+        params: Optional[Dict[str, Any]] = None,
         *args: Any,
         **kwargs: Any,
     ) -> Union[List[Like], Optional[TracksList]]:
@@ -303,9 +324,11 @@ class LikesMixin(ClientBase):
         result = await self._request.get(url, params, *args, **kwargs)
 
         if object_type == 'track':
-            return TracksList.de_json(result.get('library'), self)
+            if is_dict(result):
+                return TracksList.de_json(result.get('library'), self)
+            return None
 
-        return Like.de_list(result, self, object_type)
+        return list(Like.de_list(result, self, object_type))
 
     @log
     async def users_likes_tracks(
@@ -430,7 +453,9 @@ class LikesMixin(ClientBase):
             url, {'if_modified_since_revision': if_modified_since_revision}, *args, **kwargs
         )
 
-        return TracksList.de_json(result.get('library'), self)
+        if is_dict(result):
+            return TracksList.de_json(result.get('library'), self)
+        return None
 
     async def _dislike_action(
         self,
@@ -465,7 +490,7 @@ class LikesMixin(ClientBase):
 
         result = await self._request.post(url, {'track-ids': ids}, *args, **kwargs)
 
-        return 'revision' in result
+        return is_dict(result) and 'revision' in result
 
     @log
     async def users_dislikes_tracks_add(

--- a/yandex_music/_client_async/playlists.py
+++ b/yandex_music/_client_async/playlists.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from yandex_music import Playlist, PlaylistRecommendations, UserSettings
 from yandex_music._client_async import log
-from yandex_music._client_base import ClientBase, UserIdType
+from yandex_music._client_base import ClientBase, UserIdType, is_dict
 from yandex_music.utils.difference import Difference
 
 if TYPE_CHECKING:
@@ -40,7 +40,9 @@ class PlaylistsMixin(ClientBase):
 
         result = await self._request.get(url, *args, **kwargs)
 
-        return UserSettings.de_json(result.get('userSettings'), self)
+        if is_dict(result):
+            return UserSettings.de_json(result.get('userSettings'), self)
+        return None
 
     @log
     async def users_playlists(
@@ -78,7 +80,7 @@ class PlaylistsMixin(ClientBase):
             data = {'kinds': kind}
 
             result = await self._request.post(url, data, *args, **kwargs)
-            return Playlist.de_list(result, self)
+            return list(Playlist.de_list(result, self))
 
         url = f'{self.base_url}/users/{user_id}/playlists/{kind}'
         result = await self._request.get(url, *args, **kwargs)
@@ -414,7 +416,7 @@ class PlaylistsMixin(ClientBase):
 
         result = await self._request.get(url, *args, **kwargs)
 
-        return Playlist.de_list(result, self)
+        return list(Playlist.de_list(result, self))
 
     # camelCase псевдонимы
 

--- a/yandex_music/_client_async/queue.py
+++ b/yandex_music/_client_async/queue.py
@@ -1,8 +1,8 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 from yandex_music import Queue, QueueItem
 from yandex_music._client_async import log
-from yandex_music._client_base import ClientBase
+from yandex_music._client_base import ClientBase, is_dict
 
 if TYPE_CHECKING:
     from yandex_music.utils.request_async import Request
@@ -42,7 +42,9 @@ class QueueMixin(ClientBase):
         self._request.headers['X-Yandex-Music-Device'] = device
         result = await self._request.get(url, *args, **kwargs)
 
-        return QueueItem.de_list(result.get('queues'), self)
+        if is_dict(result):
+            return list(QueueItem.de_list(result.get('queues'), self))
+        return []
 
     @log
     async def queue(self, queue_id: str, *args: Any, **kwargs: Any) -> Optional[Queue]:
@@ -97,7 +99,7 @@ class QueueMixin(ClientBase):
             url, {'isInteractive': False}, params={'currentIndex': current_index}, **kwargs
         )
 
-        return result.get('status') == 'ok'
+        return is_dict(result) and result.get('status') == 'ok'
 
     @log
     async def queue_create(
@@ -128,7 +130,9 @@ class QueueMixin(ClientBase):
         self._request.headers['X-Yandex-Music-Device'] = device
         result = await self._request.post(url, queue, *args, **kwargs)
 
-        return result.get('id')
+        if is_dict(result):
+            return cast('Optional[str]', result.get('id'))
+        return None
 
     # camelCase псевдонимы
 

--- a/yandex_music/_client_async/radio.py
+++ b/yandex_music/_client_async/radio.py
@@ -88,7 +88,7 @@ class RadioMixin(ClientBase):
 
         result = await self._request.get(url, {'language': language}, *args, **kwargs)
 
-        return StationResult.de_list(result, self)
+        return list(StationResult.de_list(result, self))
 
     @log
     async def rotor_station_feedback(
@@ -283,7 +283,7 @@ class RadioMixin(ClientBase):
 
         result = await self._request.get(url, *args, **kwargs)
 
-        return StationResult.de_list(result, self)
+        return list(StationResult.de_list(result, self))
 
     @log
     async def rotor_station_settings2(

--- a/yandex_music/_client_async/tracks.py
+++ b/yandex_music/_client_async/tracks.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from yandex_music import Album, DownloadInfo, ShotEvent, SimilarTracks, Supplement, TrackLyrics
 from yandex_music._client_async import log
-from yandex_music._client_base import ClientBase
+from yandex_music._client_base import ClientBase, is_dict
 from yandex_music.utils.sign_request import get_sign_request
 
 if TYPE_CHECKING:
@@ -275,7 +275,9 @@ class TracksMixin(ClientBase):
 
         # TODO (MarshalX) судя по всему ручка ещё возвращает рекламу после треков для пользователей без подписки.
         #  https://github.com/MarshalX/yandex-music-api/issues/557
-        return ShotEvent.de_json(result.get('shotEvent'), self)
+        if is_dict(result):
+            return ShotEvent.de_json(result.get('shotEvent'), self)
+        return None
 
     # camelCase псевдонимы
 

--- a/yandex_music/_client_base.py
+++ b/yandex_music/_client_base.py
@@ -1,7 +1,9 @@
 import logging
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
-from yandex_music import Album, Artist, Playlist, Status, Track, YandexMusicObject
+from typing_extensions import TypeGuard
+
+from yandex_music import Album, Artist, JSONType, Playlist, Status, Track, YandexMusicObject
 
 de_list = {
     'artist': Artist.de_list,
@@ -14,6 +16,11 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 UserIdType = Optional[Union[str, int]]
 TimestampType = Optional[Union[str, float, int]]
+
+
+def is_dict(data: Optional[JSONType]) -> TypeGuard[Dict[str, JSONType]]:
+    """TypeGuard для сужения JSONType до словаря."""
+    return isinstance(data, dict)
 
 
 class ClientBase(YandexMusicObject):
@@ -30,4 +37,4 @@ class ClientBase(YandexMusicObject):
     language: str
     device: str
     me: Optional[Status] = None
-    account_uid: Optional[str] = None
+    account_uid: Optional[int] = None

--- a/yandex_music/client.py
+++ b/yandex_music/client.py
@@ -99,7 +99,7 @@ class Client(
         )
 
         self.me: Optional['Status'] = None
-        self.account_uid: Optional[str] = None
+        self.account_uid: Optional[int] = None
 
     @property
     def request(self) -> Request:

--- a/yandex_music/client_async.py
+++ b/yandex_music/client_async.py
@@ -95,7 +95,7 @@ class ClientAsync(
         )
 
         self.me: Optional['Status'] = None
-        self.account_uid: Optional[str] = None
+        self.account_uid: Optional[int] = None
 
     @property
     def request(self) -> Request:

--- a/yandex_music/utils/request.py
+++ b/yandex_music/utils/request.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from yandex_music.exceptions import NetworkError, TimedOutError
 from yandex_music.utils.request_base import (
@@ -76,7 +76,7 @@ class Request(RequestBase):
         return None
 
     def get(
-        self, url: str, params: 'JSONType' = None, timeout: 'TimeoutType' = default_timeout, **kwargs: Any
+        self, url: str, params: Optional[Dict[str, Any]] = None, timeout: 'TimeoutType' = default_timeout, **kwargs: Any
     ) -> Optional['JSONType']:
         """Отправка GET запроса.
 
@@ -103,7 +103,11 @@ class Request(RequestBase):
         return None
 
     def post(
-        self, url: str, data: 'JSONType', timeout: 'TimeoutType' = default_timeout, **kwargs: Any
+        self,
+        url: str,
+        data: Optional[Union[Dict[str, Any], str]] = None,
+        timeout: 'TimeoutType' = default_timeout,
+        **kwargs: Any,
     ) -> Optional['JSONType']:
         """Отправка POST запроса.
 

--- a/yandex_music/utils/request_async.py
+++ b/yandex_music/utils/request_async.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from yandex_music.exceptions import NetworkError, TimedOutError
 from yandex_music.utils.request_base import (
@@ -97,7 +97,7 @@ class Request(RequestBase):
         return None
 
     async def get(
-        self, url: str, params: 'JSONType' = None, timeout: 'TimeoutType' = default_timeout, **kwargs: Any
+        self, url: str, params: Optional[Dict[str, Any]] = None, timeout: 'TimeoutType' = default_timeout, **kwargs: Any
     ) -> Optional['JSONType']:
         """Отправка GET запроса.
 
@@ -124,7 +124,11 @@ class Request(RequestBase):
         return None
 
     async def post(
-        self, url: str, data: 'JSONType', timeout: 'TimeoutType' = default_timeout, **kwargs: Any
+        self,
+        url: str,
+        data: Optional[Union[Dict[str, Any], str]] = None,
+        timeout: 'TimeoutType' = default_timeout,
+        **kwargs: Any,
     ) -> Optional['JSONType']:
         """Отправка POST запроса.
 


### PR DESCRIPTION
- Типизация параметров Request.get/post (Dict[str, Any] вместо JSONType)
- TypeGuard is_dict() для сужения JSONType при вызовах result.get()
- Overload-перегрузки для _get_list и _get_likes по Literal-типам
- Исправлен тип account_uid (Optional[int])
- cast(F, wrapper) в декораторе log
- list() обёртка для de_list возвращающего Sequence