### PR TITLE
Добавлены маршруты артистов, концертов и закреплённых элементов (pins)

### DIFF
--- a/docs/source/yandex_music.artist.artist_link.rst
+++ b/docs/source/yandex_music.artist.artist_link.rst
@@ -1,0 +1,7 @@
+yandex\_music.artist.artist\_link
+=================================
+
+.. automodule:: yandex_music.artist.artist_link
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.artist.rst
+++ b/docs/source/yandex_music.artist.rst
@@ -14,6 +14,7 @@ Submodules
 
    yandex_music.artist.artist
    yandex_music.artist.artist_albums
+   yandex_music.artist.artist_link
    yandex_music.artist.artist_tracks
    yandex_music.artist.brief_info
    yandex_music.artist.counts

--- a/docs/source/yandex_music.concert.artist_concerts.rst
+++ b/docs/source/yandex_music.concert.artist_concerts.rst
@@ -1,0 +1,7 @@
+yandex\_music.concert.artist\_concerts
+======================================
+
+.. automodule:: yandex_music.concert.artist_concerts
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.concert.concert.rst
+++ b/docs/source/yandex_music.concert.concert.rst
@@ -1,0 +1,7 @@
+yandex\_music.concert.concert
+=============================
+
+.. automodule:: yandex_music.concert.concert
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.concert.concert_cashback.rst
+++ b/docs/source/yandex_music.concert.concert_cashback.rst
@@ -1,0 +1,7 @@
+yandex\_music.concert.concert\_cashback
+=======================================
+
+.. automodule:: yandex_music.concert.concert_cashback
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.concert.concert_event_info.rst
+++ b/docs/source/yandex_music.concert.concert_event_info.rst
@@ -1,0 +1,7 @@
+yandex\_music.concert.concert\_event\_info
+==========================================
+
+.. automodule:: yandex_music.concert.concert_event_info
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.concert.concert_min_price.rst
+++ b/docs/source/yandex_music.concert.concert_min_price.rst
@@ -1,0 +1,7 @@
+yandex\_music.concert.concert\_min\_price
+=========================================
+
+.. automodule:: yandex_music.concert.concert_min_price
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.concert.rst
+++ b/docs/source/yandex_music.concert.rst
@@ -1,0 +1,19 @@
+yandex\_music.concert
+=====================
+
+.. automodule:: yandex_music.concert
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   yandex_music.concert.artist_concerts
+   yandex_music.concert.concert
+   yandex_music.concert.concert_cashback
+   yandex_music.concert.concert_event_info
+   yandex_music.concert.concert_min_price

--- a/docs/source/yandex_music.content_restrictions.rst
+++ b/docs/source/yandex_music.content_restrictions.rst
@@ -1,0 +1,7 @@
+yandex\_music.content\_restrictions
+===================================
+
+.. automodule:: yandex_music.content_restrictions
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.cover_derived_colors.rst
+++ b/docs/source/yandex_music.cover_derived_colors.rst
@@ -1,0 +1,7 @@
+yandex\_music.cover\_derived\_colors
+====================================
+
+.. automodule:: yandex_music.cover_derived_colors
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.pin.pin.rst
+++ b/docs/source/yandex_music.pin.pin.rst
@@ -1,0 +1,7 @@
+yandex\_music.pin.pin
+=====================
+
+.. automodule:: yandex_music.pin.pin
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.pin.pin_data.rst
+++ b/docs/source/yandex_music.pin.pin_data.rst
@@ -1,0 +1,7 @@
+yandex\_music.pin.pin\_data
+===========================
+
+.. automodule:: yandex_music.pin.pin_data
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.pin.rst
+++ b/docs/source/yandex_music.pin.rst
@@ -1,0 +1,16 @@
+yandex\_music.pin
+=================
+
+.. automodule:: yandex_music.pin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   yandex_music.pin.pin
+   yandex_music.pin.pin_data

--- a/docs/source/yandex_music.rst
+++ b/docs/source/yandex_music.rst
@@ -15,9 +15,11 @@ Subpackages
    yandex_music.account
    yandex_music.album
    yandex_music.artist
+   yandex_music.concert
    yandex_music.feed
    yandex_music.genre
    yandex_music.landing
+   yandex_music.pin
    yandex_music.playlist
    yandex_music.queue
    yandex_music.rotor
@@ -36,7 +38,9 @@ Submodules
    yandex_music.base
    yandex_music.client
    yandex_music.client_async
+   yandex_music.content_restrictions
    yandex_music.cover
+   yandex_music.cover_derived_colors
    yandex_music.download_info
    yandex_music.exceptions
    yandex_music.experiments

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,9 @@ from .test_album_event import TestAlbumEvent
 from .test_alert import TestAlert
 from .test_alert_button import TestAlertButton
 from .test_artist import TestArtist
+from .test_artist_concerts import TestArtistConcerts
 from .test_artist_event import TestArtistEvent
+from .test_artist_link import TestArtistLink
 from .test_auto_renewable import TestAutoRenewable
 from .test_best import TestBest
 from .test_block import TestBlock
@@ -16,10 +18,16 @@ from .test_chart import TestChart
 from .test_chart_info import TestChartInfo
 from .test_chart_info_menu import TestChartInfoMenu
 from .test_chart_info_menu_item import TestChartInfoMenuItem
+from .test_concert import TestConcert
+from .test_concert_cashback import TestConcertCashback
+from .test_concert_event_info import TestConcertEventInfo
+from .test_concert_min_price import TestConcertMinPrice
+from .test_content_restrictions import TestContentRestrictions
 from .test_contest import TestContest
 from .test_context import TestContext
 from .test_counts import TestCounts
 from .test_cover import TestCover
+from .test_cover_derived_colors import TestCoverDerivedColors
 from .test_custom_wave import TestCustomWave
 from .test_day import TestDay
 from .test_deactivation import TestDeactivation
@@ -52,6 +60,8 @@ from .test_pager import TestPager
 from .test_passport_phone import TestPassportPhone
 from .test_permissions import TestPermissions
 from .test_personal_playlists_data import TestPersonalPlaylistsData
+from .test_pin import TestPin
+from .test_pin_data import TestPinData
 from .test_play_context import TestPlayContext
 from .test_play_contexts_data import TestPlayContextsData
 from .test_play_counter import TestPlayCounter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,9 @@ from yandex_music import (
     Alert,
     AlertButton,
     Artist,
+    ArtistConcerts,
     ArtistEvent,
+    ArtistLink,
     AutoRenewable,
     Best,
     Block,
@@ -22,10 +24,16 @@ from yandex_music import (
     ChartInfoMenuItem,
     ChartItem,
     Client,
+    Concert,
+    ConcertCashback,
+    ConcertEventInfo,
+    ConcertMinPrice,
+    ContentRestrictions,
     Contest,
     Context,
     Counts,
     Cover,
+    CoverDerivedColors,
     CustomWave,
     Day,
     Deactivation,
@@ -57,6 +65,8 @@ from yandex_music import (
     PassportPhone,
     Permissions,
     PersonalPlaylistsData,
+    Pin,
+    PinData,
     PlayContext,
     PlayContextsData,
     PlayCounter,
@@ -107,7 +117,9 @@ from . import (
     TestAlert,
     TestAlertButton,
     TestArtist,
+    TestArtistConcerts,
     TestArtistEvent,
+    TestArtistLink,
     TestAutoRenewable,
     TestBest,
     TestBlock,
@@ -117,10 +129,16 @@ from . import (
     TestChart,
     TestChartInfo,
     TestChartInfoMenuItem,
+    TestConcert,
+    TestConcertCashback,
+    TestConcertEventInfo,
+    TestConcertMinPrice,
+    TestContentRestrictions,
     TestContest,
     TestContext,
     TestCounts,
     TestCover,
+    TestCoverDerivedColors,
     TestCustomWave,
     TestDay,
     TestDeactivation,
@@ -151,6 +169,8 @@ from . import (
     TestPassportPhone,
     TestPermissions,
     TestPersonalPlaylistsData,
+    TestPin,
+    TestPinData,
     TestPlayContext,
     TestPlayCounter,
     TestPlaylist,
@@ -195,7 +215,7 @@ from . import (
 
 
 @pytest.fixture(scope='session')
-def artist_factory(cover, counts, ratings, link, description):
+def artist_factory(cover, counts, ratings, link, description, content_restrictions):
     class ArtistFactory:
         def get(self, popular_tracks, decomposed=None):
             return Artist(
@@ -229,6 +249,8 @@ def artist_factory(cover, counts, ratings, link, description):
                 TestArtist.init_date,
                 TestArtist.end_date,
                 TestArtist.ya_money_id,
+                TestArtist.disclaimers,
+                content_restrictions,
             )
 
     return ArtistFactory()
@@ -625,7 +647,25 @@ def icon():
 
 
 @pytest.fixture(scope='session')
-def cover():
+def content_restrictions():
+    return ContentRestrictions(
+        TestContentRestrictions.available,
+        TestContentRestrictions.disclaimers,
+    )
+
+
+@pytest.fixture(scope='session')
+def cover_derived_colors():
+    return CoverDerivedColors(
+        TestCoverDerivedColors.average,
+        TestCoverDerivedColors.wave_text,
+        TestCoverDerivedColors.mini_player,
+        TestCoverDerivedColors.accent,
+    )
+
+
+@pytest.fixture(scope='session')
+def cover(cover_derived_colors):
     return Cover(
         TestCover.type,
         TestCover.uri,
@@ -638,6 +678,59 @@ def cover():
         TestCover.copyright_cline,
         TestCover.prefix,
         TestCover.error,
+        TestCover.color,
+        cover_derived_colors,
+    )
+
+
+@pytest.fixture(scope='session')
+def concert_min_price():
+    return ConcertMinPrice(
+        TestConcertMinPrice.value,
+        TestConcertMinPrice.currency,
+        TestConcertMinPrice.currency_symbol,
+    )
+
+
+@pytest.fixture(scope='session')
+def concert_cashback():
+    return ConcertCashback(
+        TestConcertCashback.title,
+        TestConcertCashback.value_percent,
+    )
+
+
+@pytest.fixture(scope='session')
+def concert_event_info():
+    return ConcertEventInfo(
+        TestConcertEventInfo.type,
+    )
+
+
+@pytest.fixture(scope='session')
+def concert(concert_min_price, concert_cashback, concert_event_info):
+    return Concert(
+        TestConcert.id,
+        TestConcert.images,
+        TestConcert.image_url,
+        TestConcert.concert_title,
+        TestConcert.afisha_url,
+        TestConcert.city,
+        TestConcert.place,
+        TestConcert.address,
+        TestConcert.datetime,
+        TestConcert.content_rating,
+        concert_min_price,
+        concert_cashback,
+        concert_event_info,
+    )
+
+
+@pytest.fixture(scope='session')
+def artist_concerts(concert):
+    return ArtistConcerts(
+        TestArtistConcerts.artist_title,
+        [concert],
     )
 
 
@@ -1333,3 +1426,54 @@ def lyrics_info():
 @pytest.fixture(scope='session')
 def stats():
     return Stats(TestStats.last_month_listeners, TestStats.last_month_listeners_delta)
+
+
+@pytest.fixture(scope='session')
+def pin_data_artist(cover, content_restrictions):
+    return PinData(
+        id=TestPinData.id,
+        name=TestPinData.name,
+        cover=cover,
+        content_restrictions=content_restrictions,
+    )
+
+
+@pytest.fixture(scope='session')
+def pin_data_album(cover, content_restrictions):
+    return PinData(
+        id=TestPinData.id,
+        title=TestPinData.title,
+        cover=cover,
+        content_restrictions=content_restrictions,
+    )
+
+
+@pytest.fixture(scope='session')
+def pin_data_playlist(cover):
+    return PinData(
+        uid=TestPinData.uid,
+        kind=TestPinData.kind,
+        playlist_uuid=TestPinData.playlist_uuid,
+        title=TestPinData.title,
+        cover=cover,
+    )
+
+
+@pytest.fixture(scope='session')
+def pin_artist(pin_data_artist):
+    return Pin(type=TestPin.type_artist, data=pin_data_artist)
+
+
+@pytest.fixture(scope='session')
+def pin_album(pin_data_album):
+    return Pin(type=TestPin.type_album, data=pin_data_album)
+
+
+@pytest.fixture(scope='session')
+def pin_playlist(pin_data_playlist):
+    return Pin(type=TestPin.type_playlist, data=pin_data_playlist)
+
+
+@pytest.fixture(scope='session')
+def artist_link():
+    return ArtistLink(TestArtistLink.title, TestArtistLink.subtitle, TestArtistLink.url, TestArtistLink.img_url)

--- a/tests/test_artist.py
+++ b/tests/test_artist.py
@@ -31,9 +31,19 @@ class TestArtist:
     init_date = '1935-01-08'
     end_date = None
     ya_money_id = '4100170623944'
+    disclaimers = ['foreignAgent']
 
     def test_expected_values(
-        self, artist, cover, counts, ratings, link, track_without_artists_and_albums, description, artist_decomposed
+        self,
+        artist,
+        cover,
+        counts,
+        ratings,
+        link,
+        track_without_artists_and_albums,
+        description,
+        artist_decomposed,
+        content_restrictions,
     ):
         assert artist.id == self.id
         assert artist.error == self.error
@@ -65,6 +75,8 @@ class TestArtist:
         assert artist.init_date == self.init_date
         assert artist.end_date == self.end_date
         assert artist.ya_money_id == self.ya_money_id
+        assert artist.disclaimers == self.disclaimers
+        assert artist.content_restrictions == content_restrictions
 
     def test_de_json_none(self, client):
         assert Artist.de_json({}, client) is None
@@ -83,7 +95,16 @@ class TestArtist:
         assert artist.name == self.name
 
     def test_de_json_all(
-        self, client, cover, counts, ratings, link, track_without_artists, description, artist_decomposed
+        self,
+        client,
+        cover,
+        counts,
+        ratings,
+        link,
+        track_without_artists,
+        description,
+        artist_decomposed,
+        content_restrictions,
     ):
         artist_decomposed_dict = [item if isinstance(item, str) else item.to_dict() for item in artist_decomposed]
         json_dict = {
@@ -117,6 +138,8 @@ class TestArtist:
             'end_date': self.end_date,
             'hand_made_description': self.hand_made_description,
             'ya_money_id': self.ya_money_id,
+            'disclaimers': self.disclaimers,
+            'contentRestrictions': content_restrictions.to_dict(),
         }
         artist = Artist.de_json(json_dict, client)
 
@@ -150,6 +173,8 @@ class TestArtist:
         assert artist.init_date == self.init_date
         assert artist.end_date == self.end_date
         assert artist.ya_money_id == self.ya_money_id
+        assert artist.disclaimers == self.disclaimers
+        assert artist.content_restrictions == content_restrictions
 
     def test_equality(self, cover):
         a = Artist(self.id)

--- a/tests/test_artist_concerts.py
+++ b/tests/test_artist_concerts.py
@@ -1,0 +1,33 @@
+from yandex_music import ArtistConcerts
+
+
+class TestArtistConcerts:
+    artist_title = 'Кино'
+
+    def test_expected_value(self, artist_concerts, concert):
+        assert artist_concerts.artist_title == self.artist_title
+        assert artist_concerts.concerts == [concert]
+
+    def test_de_json_none(self, client):
+        assert ArtistConcerts.de_json({}, client) is None
+
+    def test_de_json_all(self, client, concert):
+        json_dict = {
+            'artist_title': self.artist_title,
+            'concerts': [concert.to_dict()],
+        }
+        artist_concerts = ArtistConcerts.de_json(json_dict, client)
+
+        assert artist_concerts.artist_title == self.artist_title
+        assert artist_concerts.concerts == [concert]
+
+    def test_equality(self, concert):
+        a = ArtistConcerts(artist_title=self.artist_title, concerts=[concert])
+        b = ArtistConcerts(artist_title='Другой артист', concerts=[])
+        c = ArtistConcerts(artist_title=self.artist_title, concerts=[concert])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_artist_link.py
+++ b/tests/test_artist_link.py
@@ -1,0 +1,46 @@
+from yandex_music import ArtistLink
+
+
+class TestArtistLink:
+    title = 'Official Site'
+    subtitle = 'example.com'
+    url = 'https://example.com'
+    img_url = 'avatars.yandex.net/get-music-misc/12345/img.abc123/%%'
+
+    def test_expected_values(self, artist_link):
+        assert artist_link.title == self.title
+        assert artist_link.subtitle == self.subtitle
+        assert artist_link.url == self.url
+        assert artist_link.img_url == self.img_url
+
+    def test_de_json_none(self, client):
+        assert ArtistLink.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'title': self.title,
+            'subtitle': self.subtitle,
+            'url': self.url,
+            'img_url': self.img_url,
+        }
+        artist_link = ArtistLink.de_json(json_dict, client)
+
+        assert artist_link.title == self.title
+        assert artist_link.subtitle == self.subtitle
+        assert artist_link.url == self.url
+        assert artist_link.img_url == self.img_url
+
+    def test_de_list_none(self, client):
+        assert ArtistLink.de_list([], client) == []
+
+    def test_equality(self):
+        a = ArtistLink(self.title, self.subtitle, self.url, self.img_url)
+        b = ArtistLink(self.title, self.subtitle, '', self.img_url)
+        c = ArtistLink('', self.subtitle, self.url, self.img_url)
+        d = ArtistLink(self.title, self.subtitle, self.url, self.img_url)
+
+        assert a != b != c
+        assert hash(a) != hash(b) != hash(c)
+        assert a is not b is not c
+
+        assert a == d

--- a/tests/test_concert.py
+++ b/tests/test_concert.py
@@ -1,0 +1,78 @@
+from yandex_music import Concert
+
+
+class TestConcert:
+    id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    images = [
+        'https://avatars.mds.yandex.net/get-afisha/1234/image1',
+        'https://avatars.mds.yandex.net/get-afisha/1234/image2',
+    ]
+    image_url = 'https://avatars.mds.yandex.net/get-afisha/1234/main'
+    concert_title = 'Большой весенний концерт'
+    afisha_url = 'https://afisha.yandex.ru/event/a1b2c3d4-e5f6'
+    city = 'Москва'
+    place = 'Крокус Сити Холл'
+    address = 'МКАД, 65-66 км'
+    datetime = '2026-06-15T19:00:00+03:00'
+    content_rating = '16+'
+
+    def test_expected_value(self, concert, concert_min_price, concert_cashback, concert_event_info):
+        assert concert.id == self.id
+        assert concert.images == self.images
+        assert concert.image_url == self.image_url
+        assert concert.concert_title == self.concert_title
+        assert concert.afisha_url == self.afisha_url
+        assert concert.city == self.city
+        assert concert.place == self.place
+        assert concert.address == self.address
+        assert concert.datetime == self.datetime
+        assert concert.content_rating == self.content_rating
+        assert concert.min_price == concert_min_price
+        assert concert.cashback == concert_cashback
+        assert concert.event_info == concert_event_info
+
+    def test_de_json_none(self, client):
+        assert Concert.de_json({}, client) is None
+
+    def test_de_json_all(self, client, concert_min_price, concert_cashback, concert_event_info):
+        json_dict = {
+            'id': self.id,
+            'images': self.images,
+            'image_url': self.image_url,
+            'concert_title': self.concert_title,
+            'afisha_url': self.afisha_url,
+            'city': self.city,
+            'place': self.place,
+            'address': self.address,
+            'datetime': self.datetime,
+            'content_rating': self.content_rating,
+            'min_price': concert_min_price.to_dict(),
+            'cashback': concert_cashback.to_dict(),
+            'event_info': concert_event_info.to_dict(),
+        }
+        concert = Concert.de_json(json_dict, client)
+
+        assert concert.id == self.id
+        assert concert.images == self.images
+        assert concert.image_url == self.image_url
+        assert concert.concert_title == self.concert_title
+        assert concert.afisha_url == self.afisha_url
+        assert concert.city == self.city
+        assert concert.place == self.place
+        assert concert.address == self.address
+        assert concert.datetime == self.datetime
+        assert concert.content_rating == self.content_rating
+        assert concert.min_price == concert_min_price
+        assert concert.cashback == concert_cashback
+        assert concert.event_info == concert_event_info
+
+    def test_equality(self):
+        a = Concert(id=self.id)
+        b = Concert(id='different-uuid-here')
+        c = Concert(id=self.id)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_concert_cashback.py
+++ b/tests/test_concert_cashback.py
@@ -1,0 +1,34 @@
+from yandex_music import ConcertCashback
+
+
+class TestConcertCashback:
+    title = 'Кешбэк до 20%'
+    value_percent = 20
+
+    def test_expected_value(self, concert_cashback):
+        assert concert_cashback.title == self.title
+        assert concert_cashback.value_percent == self.value_percent
+
+    def test_de_json_none(self, client):
+        assert ConcertCashback.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'title': self.title,
+            'value_percent': self.value_percent,
+        }
+        concert_cashback = ConcertCashback.de_json(json_dict, client)
+
+        assert concert_cashback.title == self.title
+        assert concert_cashback.value_percent == self.value_percent
+
+    def test_equality(self):
+        a = ConcertCashback(title=self.title, value_percent=self.value_percent)
+        b = ConcertCashback(title='Кешбэк до 10%', value_percent=10)
+        c = ConcertCashback(title=self.title, value_percent=self.value_percent)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_concert_event_info.py
+++ b/tests/test_concert_event_info.py
@@ -1,0 +1,30 @@
+from yandex_music import ConcertEventInfo
+
+
+class TestConcertEventInfo:
+    type = 'concert'
+
+    def test_expected_value(self, concert_event_info):
+        assert concert_event_info.type == self.type
+
+    def test_de_json_none(self, client):
+        assert ConcertEventInfo.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'type': self.type,
+        }
+        concert_event_info = ConcertEventInfo.de_json(json_dict, client)
+
+        assert concert_event_info.type == self.type
+
+    def test_equality(self):
+        a = ConcertEventInfo(type=self.type)
+        b = ConcertEventInfo(type='festival')
+        c = ConcertEventInfo(type=self.type)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_concert_min_price.py
+++ b/tests/test_concert_min_price.py
@@ -1,0 +1,38 @@
+from yandex_music import ConcertMinPrice
+
+
+class TestConcertMinPrice:
+    value = 2500
+    currency = 'RUB'
+    currency_symbol = '₽'
+
+    def test_expected_value(self, concert_min_price):
+        assert concert_min_price.value == self.value
+        assert concert_min_price.currency == self.currency
+        assert concert_min_price.currency_symbol == self.currency_symbol
+
+    def test_de_json_none(self, client):
+        assert ConcertMinPrice.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'value': self.value,
+            'currency': self.currency,
+            'currency_symbol': self.currency_symbol,
+        }
+        concert_min_price = ConcertMinPrice.de_json(json_dict, client)
+
+        assert concert_min_price.value == self.value
+        assert concert_min_price.currency == self.currency
+        assert concert_min_price.currency_symbol == self.currency_symbol
+
+    def test_equality(self):
+        a = ConcertMinPrice(value=self.value, currency=self.currency)
+        b = ConcertMinPrice(value=1000, currency='USD')
+        c = ConcertMinPrice(value=self.value, currency=self.currency)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_content_restrictions.py
+++ b/tests/test_content_restrictions.py
@@ -1,0 +1,34 @@
+from yandex_music import ContentRestrictions
+
+
+class TestContentRestrictions:
+    available = True
+    disclaimers = ['foreignAgent', 'explicit']
+
+    def test_expected_values(self, content_restrictions):
+        assert content_restrictions.available == self.available
+        assert content_restrictions.disclaimers == self.disclaimers
+
+    def test_de_json_none(self, client):
+        assert ContentRestrictions.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'available': self.available,
+            'disclaimers': self.disclaimers,
+        }
+        content_restrictions = ContentRestrictions.de_json(json_dict, client)
+
+        assert content_restrictions.available == self.available
+        assert content_restrictions.disclaimers == self.disclaimers
+
+    def test_equality(self):
+        a = ContentRestrictions(available=self.available, disclaimers=self.disclaimers)
+        b = ContentRestrictions(available=False, disclaimers=[])
+        c = ContentRestrictions(available=self.available, disclaimers=self.disclaimers)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -16,8 +16,9 @@ class TestCover:
     copyright_name = 'ТАСС'
     copyright_cline = 'imago stock&people'
     error = None
+    color = '#6d6e72'
 
-    def test_expected_values(self, cover):
+    def test_expected_values(self, cover, cover_derived_colors):
         assert cover.type == self.type
         assert cover.uri == self.uri
         assert cover.items_uri == self.items_uri
@@ -29,6 +30,8 @@ class TestCover:
         assert cover.copyright_cline == self.copyright_cline
         assert cover.prefix == self.prefix
         assert cover.error == self.error
+        assert cover.color == self.color
+        assert cover.derived_colors == cover_derived_colors
 
     def test_de_json_none(self, client):
         assert Cover.de_json({}, client) is None
@@ -40,7 +43,7 @@ class TestCover:
         json_dict = {}
         Cover.de_json(json_dict, client)
 
-    def test_de_json_all(self, client):
+    def test_de_json_all(self, client, cover_derived_colors):
         json_dict = {
             'type': self.type,
             'uri': self.uri,
@@ -53,6 +56,8 @@ class TestCover:
             'error': self.error,
             'copyright_name': self.copyright_name,
             'copyright_cline': self.copyright_cline,
+            'color': self.color,
+            'derivedColors': cover_derived_colors.to_dict(),
         }
         cover = Cover.de_json(json_dict, client)
 
@@ -67,6 +72,8 @@ class TestCover:
         assert cover.copyright_cline == self.copyright_cline
         assert cover.prefix == self.prefix
         assert cover.error == self.error
+        assert cover.color == self.color
+        assert cover.derived_colors == cover_derived_colors
 
     def test_equality(self, images):
         a = Cover(self.type, self.uri, self.items_uri)

--- a/tests/test_cover_derived_colors.py
+++ b/tests/test_cover_derived_colors.py
@@ -1,0 +1,42 @@
+from yandex_music import CoverDerivedColors
+
+
+class TestCoverDerivedColors:
+    average = '#6d6e72'
+    wave_text = '#e0e0e0'
+    mini_player = '#b6b6b8'
+    accent = '#97989a'
+
+    def test_expected_values(self, cover_derived_colors):
+        assert cover_derived_colors.average == self.average
+        assert cover_derived_colors.wave_text == self.wave_text
+        assert cover_derived_colors.mini_player == self.mini_player
+        assert cover_derived_colors.accent == self.accent
+
+    def test_de_json_none(self, client):
+        assert CoverDerivedColors.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'average': self.average,
+            'waveText': self.wave_text,
+            'miniPlayer': self.mini_player,
+            'accent': self.accent,
+        }
+        cover_derived_colors = CoverDerivedColors.de_json(json_dict, client)
+
+        assert cover_derived_colors.average == self.average
+        assert cover_derived_colors.wave_text == self.wave_text
+        assert cover_derived_colors.mini_player == self.mini_player
+        assert cover_derived_colors.accent == self.accent
+
+    def test_equality(self):
+        a = CoverDerivedColors(average=self.average, wave_text=self.wave_text)
+        b = CoverDerivedColors(average='#000000', wave_text='#ffffff')
+        c = CoverDerivedColors(average=self.average, wave_text=self.wave_text)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_pin.py
+++ b/tests/test_pin.py
@@ -1,0 +1,78 @@
+from tests.test_pin_data import TestPinData
+from yandex_music import Pin
+
+
+class TestPin:
+    type_artist = 'artist_item'
+    type_album = 'album_item'
+    type_playlist = 'playlist_item'
+
+    def test_expected_value_artist(self, pin_artist, pin_data_artist):
+        assert pin_artist.type == self.type_artist
+        assert pin_artist.data == pin_data_artist
+
+    def test_expected_value_album(self, pin_album, pin_data_album):
+        assert pin_album.type == self.type_album
+        assert pin_album.data == pin_data_album
+
+    def test_expected_value_playlist(self, pin_playlist, pin_data_playlist):
+        assert pin_playlist.type == self.type_playlist
+        assert pin_playlist.data == pin_data_playlist
+
+    def test_de_json_none(self, client):
+        assert Pin.de_json({}, client) is None
+
+    def test_de_list_none(self, client):
+        assert Pin.de_list([], client) == []
+
+    def test_de_json_artist(self, client, cover, content_restrictions):
+        json_dict = {
+            'type': self.type_artist,
+            'data': {
+                'id': TestPinData.id,
+                'name': TestPinData.name,
+                'cover': cover.to_dict(),
+                'contentRestrictions': content_restrictions.to_dict(),
+            },
+        }
+        pin = Pin.de_json(json_dict, client)
+
+        assert pin.type == self.type_artist
+        assert pin.data.id == TestPinData.id
+        assert pin.data.name == TestPinData.name
+
+    def test_de_list(self, client, cover):
+        json_list = [
+            {
+                'type': self.type_artist,
+                'data': {
+                    'id': TestPinData.id,
+                    'name': TestPinData.name,
+                    'cover': cover.to_dict(),
+                },
+            },
+            {
+                'type': self.type_album,
+                'data': {
+                    'id': TestPinData.id,
+                    'title': TestPinData.title,
+                    'cover': cover.to_dict(),
+                },
+            },
+        ]
+        pins = Pin.de_list(json_list, client)
+
+        assert len(pins) == 2
+        assert pins[0].type == self.type_artist
+        assert pins[1].type == self.type_album
+
+    def test_equality(self, pin_data_artist):
+        a = Pin(type=self.type_artist, data=pin_data_artist)
+        b = Pin(type=self.type_album, data=pin_data_artist)
+        c = Pin(type=self.type_artist, data=pin_data_artist)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_pin_data.py
+++ b/tests/test_pin_data.py
@@ -1,0 +1,71 @@
+from yandex_music import PinData
+
+
+class TestPinData:
+    id = 12345
+    uid = 100500
+    kind = 3
+    playlist_uuid = 'lk.a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    name = 'Test Artist'
+    title = 'Test Album'
+
+    def test_expected_values_artist(self, pin_data_artist, cover, content_restrictions):
+        assert pin_data_artist.id == self.id
+        assert pin_data_artist.name == self.name
+        assert pin_data_artist.cover == cover
+        assert pin_data_artist.content_restrictions == content_restrictions
+
+    def test_expected_value_album(self, pin_data_album, cover, content_restrictions):
+        assert pin_data_album.id == self.id
+        assert pin_data_album.title == self.title
+        assert pin_data_album.cover == cover
+        assert pin_data_album.content_restrictions == content_restrictions
+
+    def test_expected_value_playlist(self, pin_data_playlist, cover):
+        assert pin_data_playlist.uid == self.uid
+        assert pin_data_playlist.kind == self.kind
+        assert pin_data_playlist.playlist_uuid == self.playlist_uuid
+        assert pin_data_playlist.title == self.title
+        assert pin_data_playlist.cover == cover
+
+    def test_de_json_none(self, client):
+        assert PinData.de_json({}, client) is None
+
+    def test_de_json_artist(self, client, cover, content_restrictions):
+        json_dict = {
+            'id': self.id,
+            'name': self.name,
+            'cover': cover.to_dict(),
+            'contentRestrictions': content_restrictions.to_dict(),
+        }
+        pin_data = PinData.de_json(json_dict, client)
+
+        assert pin_data.id == self.id
+        assert pin_data.name == self.name
+        assert pin_data.content_restrictions == content_restrictions
+
+    def test_de_json_playlist(self, client, cover):
+        json_dict = {
+            'uid': self.uid,
+            'kind': self.kind,
+            'playlistUuid': self.playlist_uuid,
+            'title': self.title,
+            'cover': cover.to_dict(),
+        }
+        pin_data = PinData.de_json(json_dict, client)
+
+        assert pin_data.uid == self.uid
+        assert pin_data.kind == self.kind
+        assert pin_data.playlist_uuid == self.playlist_uuid
+        assert pin_data.title == self.title
+
+    def test_equality(self, cover):
+        a = PinData(id=self.id, name=self.name, cover=cover)
+        b = PinData(id=999, name='Other', cover=cover)
+        c = PinData(id=self.id, name=self.name, cover=cover)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/yandex_music/__init__.py
+++ b/yandex_music/__init__.py
@@ -31,8 +31,9 @@ from .album.track_position import TrackPosition
 from .album.deprecation import Deprecation
 
 from .artist.artist import Artist
-from .artist.artist_tracks import ArtistTracks
 from .artist.artist_albums import ArtistAlbums
+from .artist.artist_link import ArtistLink
+from .artist.artist_tracks import ArtistTracks
 from .artist.brief_info import BriefInfo
 from .artist.counts import Counts
 from .artist.description import Description
@@ -40,6 +41,12 @@ from .artist.link import Link
 from .artist.ratings import Ratings
 from .artist.stats import Stats
 from .artist.vinyl import Vinyl
+
+from .concert.concert_min_price import ConcertMinPrice
+from .concert.concert_cashback import ConcertCashback
+from .concert.concert_event_info import ConcertEventInfo
+from .concert.concert import Concert
+from .concert.artist_concerts import ArtistConcerts
 
 from .playlist.case_forms import CaseForms
 from .playlist.made_for import MadeFor
@@ -134,12 +141,16 @@ from .queue.context import Context
 from .queue.queue import Queue
 from .queue.queue_item import QueueItem
 
+from .content_restrictions import ContentRestrictions
 from .like import Like
 from .pager import Pager
 from .cover import Cover
+from .cover_derived_colors import CoverDerivedColors
 from .invocation_info import InvocationInfo
 from .track_short import TrackShort
 from .icon import Icon
+from .pin.pin_data import PinData
+from .pin.pin import Pin
 from .client import Client
 from .client_async import ClientAsync
 
@@ -154,7 +165,9 @@ __all__ = [
     'AlertButton',
     'Artist',
     'ArtistAlbums',
+    'ArtistConcerts',
     'ArtistEvent',
+    'ArtistLink',
     'ArtistTracks',
     'AutoRenewable',
     'Best',
@@ -171,10 +184,16 @@ __all__ = [
     'Client',
     'ClientAsync',
     'ClientType',
+    'Concert',
+    'ConcertCashback',
+    'ConcertEventInfo',
+    'ConcertMinPrice',
+    'ContentRestrictions',
     'Contest',
     'Context',
     'Counts',
     'Cover',
+    'CoverDerivedColors',
     'CustomWave',
     'Dashboard',
     'Day',
@@ -217,6 +236,8 @@ __all__ = [
     'PermissionAlerts',
     'Permissions',
     'PersonalPlaylistsData',
+    'Pin',
+    'PinData',
     'PlayContext',
     'PlayContextsData',
     'PlayCounter',

--- a/yandex_music/_client/artists.py
+++ b/yandex_music/_client/artists.py
@@ -2,11 +2,11 @@
 # THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/artists.py. DON'T EDIT IT BY HANDS #
 ################################################################################################
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from yandex_music import ArtistAlbums, ArtistTracks, BriefInfo
+from yandex_music import Artist, ArtistAlbums, ArtistConcerts, ArtistLink, ArtistTracks, BriefInfo
 from yandex_music._client import log
-from yandex_music._client_base import ClientBase
+from yandex_music._client_base import ClientBase, is_dict
 
 if TYPE_CHECKING:
     from yandex_music.utils.request import Request
@@ -107,6 +107,237 @@ class ArtistsMixin(ClientBase):
 
         return ArtistAlbums.de_json(result, self)
 
+    @log
+    def artists_similar(
+        self,
+        artist_id: Union[str, int],
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Artist]:
+        """Получение похожих артистов.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`yandex_music.Artist`: Список похожих артистов.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/similar'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        if is_dict(result):
+            return list(Artist.de_list(result.get('similar_artists', []), self))
+
+        return []
+
+    @log
+    def artists_links(
+        self,
+        artist_id: Union[str, int],
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[ArtistLink]:
+        """Получение ссылок на страницы артиста.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`yandex_music.ArtistLink`: Список ссылок на страницы артиста.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/artist-links'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        if is_dict(result):
+            return list(ArtistLink.de_list(result.get('links', []), self))
+
+        return []
+
+    @log
+    def artists_also_albums(
+        self,
+        artist_id: Union[str, int],
+        page: int = 0,
+        page_size: int = 20,
+        sort_by: str = 'year',
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[ArtistAlbums]:
+        """Получение сборников и альбомов, в которых участвовал артист.
+
+        Note:
+            Известные значения для `sort_by`: `year`, `rating`.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            page (:obj:`int`, optional): Номер страницы.
+            page_size (:obj:`int`, optional): Количество альбомов на странице.
+            sort_by (:obj:`str`, optional): Параметр для сортировки.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.ArtistAlbums` | :obj:`None`: Страница списка альбомов артиста или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/also-albums'
+
+        params = {'sort-by': sort_by, 'page': page, 'page-size': page_size}
+
+        result = self._request.get(url, params, *args, **kwargs)
+
+        return ArtistAlbums.de_json(result, self)
+
+    @log
+    def artists_discography_albums(
+        self,
+        artist_id: Union[str, int],
+        page: int = 0,
+        page_size: int = 20,
+        sort_by: str = 'year',
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[ArtistAlbums]:
+        """Получение дискографии артиста.
+
+        Note:
+            Известные значения для `sort_by`: `year`, `rating`.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            page (:obj:`int`, optional): Номер страницы.
+            page_size (:obj:`int`, optional): Количество альбомов на странице.
+            sort_by (:obj:`str`, optional): Параметр для сортировки.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.ArtistAlbums` | :obj:`None`: Страница списка дискографии артиста или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/discography-albums'
+
+        params = {'sort-by': sort_by, 'page': page, 'page-size': page_size}
+
+        result = self._request.get(url, params, *args, **kwargs)
+
+        return ArtistAlbums.de_json(result, self)
+
+    @log
+    def artists_safe_direct_albums(
+        self,
+        artist_id: Union[str, int],
+        sort_by: str = 'year',
+        sort_order: str = 'desc',
+        limit: int = 20,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[ArtistAlbums]:
+        """Получение безопасных альбомов артиста.
+
+        Note:
+            Известные значения для `sort_by`: `year`, `rating`.
+            Известные значения для `sort_order`: `asc`, `desc`.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            sort_by (:obj:`str`, optional): Параметр для сортировки.
+            sort_order (:obj:`str`, optional): Порядок сортировки.
+            limit (:obj:`int`, optional): Количество альбомов.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.ArtistAlbums` | :obj:`None`: Список альбомов артиста или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/safe-direct-albums'
+
+        params = {'sort-by': sort_by, 'sort-order': sort_order, 'limit': limit}
+
+        result = self._request.get(url, params, *args, **kwargs)
+
+        return ArtistAlbums.de_json(result, self)
+
+    @log
+    def artists_track_ids(
+        self,
+        artist_id: Union[str, int],
+        page: int = 0,
+        page_size: int = 20,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Получение идентификаторов треков артиста.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            page (:obj:`int`, optional): Номер страницы.
+            page_size (:obj:`int`, optional): Количество треков на странице.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`str`: Список идентификаторов треков.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/track-ids'
+
+        params = {'page': page, 'page-size': page_size}
+
+        result = self._request.get(url, params, *args, **kwargs)
+
+        if isinstance(result, list):
+            return result
+
+        return []
+
+    @log
+    def artists_concerts(
+        self,
+        artist_id: Union[str, int],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[ArtistConcerts]:
+        """Получение концертов артиста.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.ArtistConcerts` | :obj:`None`: Информация о концертах артиста или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/concerts'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return ArtistConcerts.de_json(result, self)
+
     # camelCase псевдонимы
 
     #: Псевдоним для :attr:`artists_brief_info`
@@ -115,3 +346,17 @@ class ArtistsMixin(ClientBase):
     artistsTracks = artists_tracks
     #: Псевдоним для :attr:`artists_direct_albums`
     artistsDirectAlbums = artists_direct_albums
+    #: Псевдоним для :attr:`artists_similar`
+    artistsSimilar = artists_similar
+    #: Псевдоним для :attr:`artists_links`
+    artistsLinks = artists_links
+    #: Псевдоним для :attr:`artists_also_albums`
+    artistsAlsoAlbums = artists_also_albums
+    #: Псевдоним для :attr:`artists_discography_albums`
+    artistsDiscographyAlbums = artists_discography_albums
+    #: Псевдоним для :attr:`artists_safe_direct_albums`
+    artistsSafeDirectAlbums = artists_safe_direct_albums
+    #: Псевдоним для :attr:`artists_track_ids`
+    artistsTrackIds = artists_track_ids
+    #: Псевдоним для :attr:`artists_concerts`
+    artistsConcerts = artists_concerts

--- a/yandex_music/_client/pins.py
+++ b/yandex_music/_client/pins.py
@@ -1,0 +1,203 @@
+#############################################################################################
+# THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/pins.py. DON'T EDIT IT BY HANDS #
+#############################################################################################
+
+from typing import TYPE_CHECKING, Any, List, Optional, Union
+
+from yandex_music import Pin
+from yandex_music._client import log
+from yandex_music._client_base import ClientBase
+
+if TYPE_CHECKING:
+    from yandex_music.utils.request import Request
+
+
+class PinsMixin(ClientBase):
+    """Миксин для методов, связанных с закреплёнными элементами."""
+
+    _request: 'Request'
+
+    @log
+    def pins(self, *args: Any, **kwargs: Any) -> List[Pin]:
+        """Получение списка закреплённых элементов.
+
+        Args:
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`yandex_music.Pin`: Список закреплённых элементов.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pins'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        if isinstance(result, dict):
+            return list(Pin.de_list(result.get('pins'), self))
+
+        return []
+
+    @log
+    def pin_album(self, album_id: Union[str, int], **kwargs: Any) -> Optional[Pin]:
+        """Закрепление альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Pin`: Закреплённый элемент.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/album'
+
+        result = self._request.put(url, json={'id': album_id}, **kwargs)
+
+        return Pin.de_json(result, self)
+
+    @log
+    def unpin_album(self, album_id: Union[str, int], **kwargs: Any) -> bool:
+        """Открепление альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/album'
+
+        result = self._request.delete(url, json={'id': album_id}, **kwargs)
+
+        return result == 'ok'
+
+    @log
+    def pin_artist(self, artist_id: Union[str, int], **kwargs: Any) -> Optional[Pin]:
+        """Закрепление артиста.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Pin`: Закреплённый элемент.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/artist'
+
+        result = self._request.put(url, json={'id': artist_id}, **kwargs)
+
+        return Pin.de_json(result, self)
+
+    @log
+    def unpin_artist(self, artist_id: Union[str, int], **kwargs: Any) -> bool:
+        """Открепление артиста.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/artist'
+
+        result = self._request.delete(url, json={'id': artist_id}, **kwargs)
+
+        return result == 'ok'
+
+    @log
+    def pin_playlist(self, uid: Union[str, int], kind: Union[str, int], **kwargs: Any) -> Optional[Pin]:
+        """Закрепление плейлиста.
+
+        Args:
+            uid (:obj:`str` | :obj:`int`): Уникальный идентификатор владельца плейлиста.
+            kind (:obj:`str` | :obj:`int`): Номер плейлиста.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Pin`: Закреплённый элемент.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/playlist'
+
+        result = self._request.put(url, json={'uid': uid, 'kind': kind}, **kwargs)
+
+        return Pin.de_json(result, self)
+
+    @log
+    def unpin_playlist(self, uid: Union[str, int], kind: Union[str, int], **kwargs: Any) -> bool:
+        """Открепление плейлиста.
+
+        Args:
+            uid (:obj:`str` | :obj:`int`): Уникальный идентификатор владельца плейлиста.
+            kind (:obj:`str` | :obj:`int`): Номер плейлиста.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/playlist'
+
+        result = self._request.delete(url, json={'uid': uid, 'kind': kind}, **kwargs)
+
+        return result == 'ok'
+
+    @log
+    def pin_wave(self, seeds: str, **kwargs: Any) -> Optional[Pin]:
+        """Закрепление волны.
+
+        Args:
+            seeds (:obj:`str`): Идентификатор волны (например, "artist:12345").
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Pin`: Закреплённый элемент.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/wave'
+
+        result = self._request.put(url, json={'seeds': seeds}, **kwargs)
+
+        return Pin.de_json(result, self)
+
+    @log
+    def unpin_wave(self, seeds: str, **kwargs: Any) -> bool:
+        """Открепление волны.
+
+        Args:
+            seeds (:obj:`str`): Идентификатор волны.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/wave'
+
+        result = self._request.delete(url, json={'seeds': seeds}, **kwargs)
+
+        return result == 'ok'

--- a/yandex_music/_client_async/artists.py
+++ b/yandex_music/_client_async/artists.py
@@ -1,8 +1,8 @@
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from yandex_music import ArtistAlbums, ArtistTracks, BriefInfo
+from yandex_music import Artist, ArtistAlbums, ArtistConcerts, ArtistLink, ArtistTracks, BriefInfo
 from yandex_music._client_async import log
-from yandex_music._client_base import ClientBase
+from yandex_music._client_base import ClientBase, is_dict
 
 if TYPE_CHECKING:
     from yandex_music.utils.request_async import Request
@@ -103,6 +103,237 @@ class ArtistsMixin(ClientBase):
 
         return ArtistAlbums.de_json(result, self)
 
+    @log
+    async def artists_similar(
+        self,
+        artist_id: Union[str, int],
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[Artist]:
+        """Получение похожих артистов.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`yandex_music.Artist`: Список похожих артистов.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/similar'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        if is_dict(result):
+            return list(Artist.de_list(result.get('similar_artists', []), self))
+
+        return []
+
+    @log
+    async def artists_links(
+        self,
+        artist_id: Union[str, int],
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[ArtistLink]:
+        """Получение ссылок на страницы артиста.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`yandex_music.ArtistLink`: Список ссылок на страницы артиста.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/artist-links'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        if is_dict(result):
+            return list(ArtistLink.de_list(result.get('links', []), self))
+
+        return []
+
+    @log
+    async def artists_also_albums(
+        self,
+        artist_id: Union[str, int],
+        page: int = 0,
+        page_size: int = 20,
+        sort_by: str = 'year',
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[ArtistAlbums]:
+        """Получение сборников и альбомов, в которых участвовал артист.
+
+        Note:
+            Известные значения для `sort_by`: `year`, `rating`.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            page (:obj:`int`, optional): Номер страницы.
+            page_size (:obj:`int`, optional): Количество альбомов на странице.
+            sort_by (:obj:`str`, optional): Параметр для сортировки.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.ArtistAlbums` | :obj:`None`: Страница списка альбомов артиста или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/also-albums'
+
+        params = {'sort-by': sort_by, 'page': page, 'page-size': page_size}
+
+        result = await self._request.get(url, params, *args, **kwargs)
+
+        return ArtistAlbums.de_json(result, self)
+
+    @log
+    async def artists_discography_albums(
+        self,
+        artist_id: Union[str, int],
+        page: int = 0,
+        page_size: int = 20,
+        sort_by: str = 'year',
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[ArtistAlbums]:
+        """Получение дискографии артиста.
+
+        Note:
+            Известные значения для `sort_by`: `year`, `rating`.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            page (:obj:`int`, optional): Номер страницы.
+            page_size (:obj:`int`, optional): Количество альбомов на странице.
+            sort_by (:obj:`str`, optional): Параметр для сортировки.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.ArtistAlbums` | :obj:`None`: Страница списка дискографии артиста или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/discography-albums'
+
+        params = {'sort-by': sort_by, 'page': page, 'page-size': page_size}
+
+        result = await self._request.get(url, params, *args, **kwargs)
+
+        return ArtistAlbums.de_json(result, self)
+
+    @log
+    async def artists_safe_direct_albums(
+        self,
+        artist_id: Union[str, int],
+        sort_by: str = 'year',
+        sort_order: str = 'desc',
+        limit: int = 20,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[ArtistAlbums]:
+        """Получение безопасных альбомов артиста.
+
+        Note:
+            Известные значения для `sort_by`: `year`, `rating`.
+            Известные значения для `sort_order`: `asc`, `desc`.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            sort_by (:obj:`str`, optional): Параметр для сортировки.
+            sort_order (:obj:`str`, optional): Порядок сортировки.
+            limit (:obj:`int`, optional): Количество альбомов.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.ArtistAlbums` | :obj:`None`: Список альбомов артиста или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/safe-direct-albums'
+
+        params = {'sort-by': sort_by, 'sort-order': sort_order, 'limit': limit}
+
+        result = await self._request.get(url, params, *args, **kwargs)
+
+        return ArtistAlbums.de_json(result, self)
+
+    @log
+    async def artists_track_ids(
+        self,
+        artist_id: Union[str, int],
+        page: int = 0,
+        page_size: int = 20,
+        *args: Any,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Получение идентификаторов треков артиста.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            page (:obj:`int`, optional): Номер страницы.
+            page_size (:obj:`int`, optional): Количество треков на странице.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`str`: Список идентификаторов треков.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/track-ids'
+
+        params = {'page': page, 'page-size': page_size}
+
+        result = await self._request.get(url, params, *args, **kwargs)
+
+        if isinstance(result, list):
+            return result
+
+        return []
+
+    @log
+    async def artists_concerts(
+        self,
+        artist_id: Union[str, int],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[ArtistConcerts]:
+        """Получение концертов артиста.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.ArtistConcerts` | :obj:`None`: Информация о концертах артиста или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/artists/{artist_id}/concerts'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return ArtistConcerts.de_json(result, self)
+
     # camelCase псевдонимы
 
     #: Псевдоним для :attr:`artists_brief_info`
@@ -111,3 +342,17 @@ class ArtistsMixin(ClientBase):
     artistsTracks = artists_tracks
     #: Псевдоним для :attr:`artists_direct_albums`
     artistsDirectAlbums = artists_direct_albums
+    #: Псевдоним для :attr:`artists_similar`
+    artistsSimilar = artists_similar
+    #: Псевдоним для :attr:`artists_links`
+    artistsLinks = artists_links
+    #: Псевдоним для :attr:`artists_also_albums`
+    artistsAlsoAlbums = artists_also_albums
+    #: Псевдоним для :attr:`artists_discography_albums`
+    artistsDiscographyAlbums = artists_discography_albums
+    #: Псевдоним для :attr:`artists_safe_direct_albums`
+    artistsSafeDirectAlbums = artists_safe_direct_albums
+    #: Псевдоним для :attr:`artists_track_ids`
+    artistsTrackIds = artists_track_ids
+    #: Псевдоним для :attr:`artists_concerts`
+    artistsConcerts = artists_concerts

--- a/yandex_music/_client_async/pins.py
+++ b/yandex_music/_client_async/pins.py
@@ -1,0 +1,199 @@
+from typing import TYPE_CHECKING, Any, List, Optional, Union
+
+from yandex_music import Pin
+from yandex_music._client_async import log
+from yandex_music._client_base import ClientBase
+
+if TYPE_CHECKING:
+    from yandex_music.utils.request_async import Request
+
+
+class PinsMixin(ClientBase):
+    """Миксин для методов, связанных с закреплёнными элементами."""
+
+    _request: 'Request'
+
+    @log
+    async def pins(self, *args: Any, **kwargs: Any) -> List[Pin]:
+        """Получение списка закреплённых элементов.
+
+        Args:
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`yandex_music.Pin`: Список закреплённых элементов.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pins'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        if isinstance(result, dict):
+            return list(Pin.de_list(result.get('pins'), self))
+
+        return []
+
+    @log
+    async def pin_album(self, album_id: Union[str, int], **kwargs: Any) -> Optional[Pin]:
+        """Закрепление альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Pin`: Закреплённый элемент.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/album'
+
+        result = await self._request.put(url, json={'id': album_id}, **kwargs)
+
+        return Pin.de_json(result, self)
+
+    @log
+    async def unpin_album(self, album_id: Union[str, int], **kwargs: Any) -> bool:
+        """Открепление альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/album'
+
+        result = await self._request.delete(url, json={'id': album_id}, **kwargs)
+
+        return result == 'ok'
+
+    @log
+    async def pin_artist(self, artist_id: Union[str, int], **kwargs: Any) -> Optional[Pin]:
+        """Закрепление артиста.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Pin`: Закреплённый элемент.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/artist'
+
+        result = await self._request.put(url, json={'id': artist_id}, **kwargs)
+
+        return Pin.de_json(result, self)
+
+    @log
+    async def unpin_artist(self, artist_id: Union[str, int], **kwargs: Any) -> bool:
+        """Открепление артиста.
+
+        Args:
+            artist_id (:obj:`str` | :obj:`int`): Уникальный идентификатор артиста.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/artist'
+
+        result = await self._request.delete(url, json={'id': artist_id}, **kwargs)
+
+        return result == 'ok'
+
+    @log
+    async def pin_playlist(self, uid: Union[str, int], kind: Union[str, int], **kwargs: Any) -> Optional[Pin]:
+        """Закрепление плейлиста.
+
+        Args:
+            uid (:obj:`str` | :obj:`int`): Уникальный идентификатор владельца плейлиста.
+            kind (:obj:`str` | :obj:`int`): Номер плейлиста.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Pin`: Закреплённый элемент.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/playlist'
+
+        result = await self._request.put(url, json={'uid': uid, 'kind': kind}, **kwargs)
+
+        return Pin.de_json(result, self)
+
+    @log
+    async def unpin_playlist(self, uid: Union[str, int], kind: Union[str, int], **kwargs: Any) -> bool:
+        """Открепление плейлиста.
+
+        Args:
+            uid (:obj:`str` | :obj:`int`): Уникальный идентификатор владельца плейлиста.
+            kind (:obj:`str` | :obj:`int`): Номер плейлиста.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/playlist'
+
+        result = await self._request.delete(url, json={'uid': uid, 'kind': kind}, **kwargs)
+
+        return result == 'ok'
+
+    @log
+    async def pin_wave(self, seeds: str, **kwargs: Any) -> Optional[Pin]:
+        """Закрепление волны.
+
+        Args:
+            seeds (:obj:`str`): Идентификатор волны (например, "artist:12345").
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Pin`: Закреплённый элемент.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/wave'
+
+        result = await self._request.put(url, json={'seeds': seeds}, **kwargs)
+
+        return Pin.de_json(result, self)
+
+    @log
+    async def unpin_wave(self, seeds: str, **kwargs: Any) -> bool:
+        """Открепление волны.
+
+        Args:
+            seeds (:obj:`str`): Идентификатор волны.
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/pin/wave'
+
+        result = await self._request.delete(url, json={'seeds': seeds}, **kwargs)
+
+        return result == 'ok'

--- a/yandex_music/artist/artist.py
+++ b/yandex_music/artist/artist.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
         ArtistAlbums,
         ArtistTracks,
         ClientType,
+        ContentRestrictions,
         Counts,
         Cover,
         Description,
@@ -55,6 +56,8 @@ class Artist(YandexMusicModel):
         init_date (:obj:`str`, optional): Дата начала в формате YYYY-MM-DD или YYYY.
         end_date (:obj:`str`, optional): Дата окончания в формате YYYY-MM-DD или YYYY.
         ya_money_id (:obj:`str`): Номер кошеляка Яндекс.Деньги TODO.
+        disclaimers (:obj:`list` из :obj:`str`, optional): Дисклеймеры, например ["foreignAgent"].
+        content_restrictions (:obj:`yandex_music.ContentRestrictions`, optional): Ограничения контента.
         client (:obj:`yandex_music.Client`): Клиент Yandex Music.
     """
 
@@ -88,6 +91,8 @@ class Artist(YandexMusicModel):
     init_date: Optional[str] = None
     end_date: Optional[str] = None
     ya_money_id: Optional[str] = None
+    disclaimers: Optional[List[str]] = None
+    content_restrictions: Optional['ContentRestrictions'] = None
     client: Optional['ClientType'] = None
 
     def __post_init__(self) -> None:
@@ -317,7 +322,7 @@ class Artist(YandexMusicModel):
             return None
 
         cls_data = cls.cleanup_data(data, client)
-        from yandex_music import Counts, Cover, Description, Link, Ratings, Track
+        from yandex_music import ContentRestrictions, Counts, Cover, Description, Link, Ratings, Track
 
         cls_data['cover'] = Cover.de_json(cls_data.get('cover'), client)
         cls_data['ratings'] = Ratings.de_json(cls_data.get('ratings'), client)
@@ -325,6 +330,7 @@ class Artist(YandexMusicModel):
         cls_data['links'] = Link.de_list(cls_data.get('links'), client)
         cls_data['popular_tracks'] = Track.de_list(cls_data.get('popular_tracks'), client)
         cls_data['description'] = Description.de_json(cls_data.get('description'), client)
+        cls_data['content_restrictions'] = ContentRestrictions.de_json(cls_data.get('content_restrictions'), client)
 
         # Мне всё равно как в яндухе на клиентах солвят свой бэковский костыль
         decomposed = cls_data.get('decomposed')

--- a/yandex_music/artist/artist_link.py
+++ b/yandex_music/artist/artist_link.py
@@ -1,0 +1,29 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class ArtistLink(YandexMusicModel):
+    """Класс, представляющий ссылку на страницу артиста.
+
+    Attributes:
+        title (:obj:`str`): Название ссылки.
+        subtitle (:obj:`str`, optional): Подзаголовок ссылки.
+        url (:obj:`str`, optional): URL ссылки.
+        img_url (:obj:`str`, optional): URL изображения.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    title: str
+    subtitle: Optional[str] = None
+    url: Optional[str] = None
+    img_url: Optional[str] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.title, self.url)

--- a/yandex_music/client.py
+++ b/yandex_music/client.py
@@ -11,6 +11,7 @@ from yandex_music._client.artists import ArtistsMixin
 from yandex_music._client.batch import BatchMixin
 from yandex_music._client.landing import LandingMixin
 from yandex_music._client.likes import LikesMixin
+from yandex_music._client.pins import PinsMixin
 from yandex_music._client.playlists import PlaylistsMixin
 from yandex_music._client.queue import QueueMixin
 from yandex_music._client.radio import RadioMixin
@@ -30,6 +31,7 @@ class Client(
     RadioMixin,
     ArtistsMixin,
     LikesMixin,
+    PinsMixin,
     QueueMixin,
     BatchMixin,
     YandexMusicObject,

--- a/yandex_music/client_async.py
+++ b/yandex_music/client_async.py
@@ -7,6 +7,7 @@ from yandex_music._client_async.artists import ArtistsMixin
 from yandex_music._client_async.batch import BatchMixin
 from yandex_music._client_async.landing import LandingMixin
 from yandex_music._client_async.likes import LikesMixin
+from yandex_music._client_async.pins import PinsMixin
 from yandex_music._client_async.playlists import PlaylistsMixin
 from yandex_music._client_async.queue import QueueMixin
 from yandex_music._client_async.radio import RadioMixin
@@ -26,6 +27,7 @@ class ClientAsync(
     RadioMixin,
     ArtistsMixin,
     LikesMixin,
+    PinsMixin,
     QueueMixin,
     BatchMixin,
     YandexMusicObject,

--- a/yandex_music/concert/artist_concerts.py
+++ b/yandex_music/concert/artist_concerts.py
@@ -1,0 +1,48 @@
+from dataclasses import field
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.concert.concert import Concert
+
+
+@model
+class ArtistConcerts(YandexMusicModel):
+    """Класс, представляющий список концертов артиста.
+
+    Attributes:
+        artist_title (:obj:`str`, optional): Название артиста.
+        concerts (:obj:`list` из :obj:`yandex_music.Concert`): Список концертов.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    artist_title: Optional[str] = None
+    concerts: List['Concert'] = field(default_factory=list)
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.artist_title, self.concerts)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['ArtistConcerts']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.ArtistConcerts`: Список концертов артиста.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.concert.concert import Concert
+
+        cls_data['concerts'] = Concert.de_list(cls_data.get('concerts'), client)
+
+        return cls(client=client, **cls_data)  # type: ignore

--- a/yandex_music/concert/concert.py
+++ b/yandex_music/concert/concert.py
@@ -1,0 +1,78 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.concert.concert_cashback import ConcertCashback
+    from yandex_music.concert.concert_event_info import ConcertEventInfo
+    from yandex_music.concert.concert_min_price import ConcertMinPrice
+
+
+@model
+class Concert(YandexMusicModel):
+    """Класс, представляющий концерт.
+
+    Note:
+        Известные значения поля event_info.type: concert, festival.
+
+    Attributes:
+        id (:obj:`str`, optional): UUID концерта.
+        images (:obj:`list` из :obj:`str`, optional): Список URL изображений.
+        image_url (:obj:`str`, optional): URL основного изображения.
+        concert_title (:obj:`str`, optional): Название концерта/фестиваля.
+        afisha_url (:obj:`str`, optional): Ссылка на страницу Афиши.
+        city (:obj:`str`, optional): Город.
+        place (:obj:`str`, optional): Площадка.
+        address (:obj:`str`, optional): Адрес.
+        datetime (:obj:`str`, optional): Дата и время (ISO 8601).
+        content_rating (:obj:`str`, optional): Возрастной рейтинг, например "16+".
+        min_price (:obj:`yandex_music.ConcertMinPrice`, optional): Минимальная цена билета.
+        cashback (:obj:`yandex_music.ConcertCashback`, optional): Информация о кешбэке.
+        event_info (:obj:`yandex_music.ConcertEventInfo`, optional): Информация о типе события.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    id: Optional[str] = None
+    images: Optional[List[str]] = None
+    image_url: Optional[str] = None
+    concert_title: Optional[str] = None
+    afisha_url: Optional[str] = None
+    city: Optional[str] = None
+    place: Optional[str] = None
+    address: Optional[str] = None
+    datetime: Optional[str] = None
+    content_rating: Optional[str] = None
+    min_price: Optional['ConcertMinPrice'] = None
+    cashback: Optional['ConcertCashback'] = None
+    event_info: Optional['ConcertEventInfo'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.id,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['Concert']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.Concert`: Концерт.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.concert.concert_cashback import ConcertCashback
+        from yandex_music.concert.concert_event_info import ConcertEventInfo
+        from yandex_music.concert.concert_min_price import ConcertMinPrice
+
+        cls_data['min_price'] = ConcertMinPrice.de_json(cls_data.get('min_price'), client)
+        cls_data['cashback'] = ConcertCashback.de_json(cls_data.get('cashback'), client)
+        cls_data['event_info'] = ConcertEventInfo.de_json(cls_data.get('event_info'), client)
+
+        return cls(client=client, **cls_data)  # type: ignore

--- a/yandex_music/concert/concert_cashback.py
+++ b/yandex_music/concert/concert_cashback.py
@@ -1,0 +1,25 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class ConcertCashback(YandexMusicModel):
+    """Класс, представляющий информацию о кешбэке за покупку билета.
+
+    Attributes:
+        title (:obj:`str`, optional): Текст кешбэка, например "Кешбэк до 20%".
+        value_percent (:obj:`int`, optional): Процент кешбэка.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    title: Optional[str] = None
+    value_percent: Optional[int] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.title, self.value_percent)

--- a/yandex_music/concert/concert_event_info.py
+++ b/yandex_music/concert/concert_event_info.py
@@ -1,0 +1,26 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class ConcertEventInfo(YandexMusicModel):
+    """Класс, представляющий информацию о типе события.
+
+    Note:
+        Известные значения поля type: concert, festival.
+
+    Attributes:
+        type (:obj:`str`, optional): Тип события.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    type: Optional[str] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.type,)

--- a/yandex_music/concert/concert_min_price.py
+++ b/yandex_music/concert/concert_min_price.py
@@ -1,0 +1,27 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class ConcertMinPrice(YandexMusicModel):
+    """Класс, представляющий минимальную цену билета на концерт.
+
+    Attributes:
+        value (:obj:`int`, optional): Значение цены.
+        currency (:obj:`str`, optional): Код валюты, например "RUB".
+        currency_symbol (:obj:`str`, optional): Символ валюты, например "₽".
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    value: Optional[int] = None
+    currency: Optional[str] = None
+    currency_symbol: Optional[str] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.value, self.currency)

--- a/yandex_music/content_restrictions.py
+++ b/yandex_music/content_restrictions.py
@@ -1,0 +1,25 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class ContentRestrictions(YandexMusicModel):
+    """Класс, представляющий ограничения контента.
+
+    Attributes:
+        available (:obj:`bool`, optional): Доступен ли контент.
+        disclaimers (:obj:`list` из :obj:`str`, optional): Список дисклеймеров.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    available: Optional[bool] = None
+    disclaimers: Optional[List[str]] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.available, self.disclaimers)

--- a/yandex_music/cover.py
+++ b/yandex_music/cover.py
@@ -4,7 +4,7 @@ from yandex_music import YandexMusicModel
 from yandex_music.utils import model
 
 if TYPE_CHECKING:
-    from yandex_music import ClientType
+    from yandex_music import ClientType, CoverDerivedColors, JSONType
 
 
 @model
@@ -23,6 +23,8 @@ class Cover(YandexMusicModel):
         copyright_name (:obj:`str`, optional): Название владельца авторским правом.
         copyright_cline (:obj:`str`, optional): Владелец прав на музыку (автор текста и т.д.), а не её записи.
         error (:obj:`str`, optional): Сообщение об ошибке.
+        color (:obj:`str`, optional): Основной цвет обложки, например "#6d6e72".
+        derived_colors (:obj:`yandex_music.CoverDerivedColors`, optional): Производные цвета обложки.
         client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
     """
 
@@ -37,10 +39,33 @@ class Cover(YandexMusicModel):
     copyright_cline: Optional[str] = None
     prefix: Optional[str] = None
     error: Optional[str] = None
+    color: Optional[str] = None
+    derived_colors: Optional['CoverDerivedColors'] = None
     client: Optional['ClientType'] = None
 
     def __post_init__(self) -> None:
         self._id_attrs = (self.prefix, self.version, self.uri, self.items_uri)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['Cover']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.Cover`: Обложка.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import CoverDerivedColors
+
+        cls_data['derived_colors'] = CoverDerivedColors.de_json(cls_data.get('derived_colors'), client)
+
+        return cls(client=client, **cls_data)
 
     def get_url(self, index: int = 0, size: str = '200x200') -> str:
         """Возвращает URL обложки.

--- a/yandex_music/cover_derived_colors.py
+++ b/yandex_music/cover_derived_colors.py
@@ -1,0 +1,29 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class CoverDerivedColors(YandexMusicModel):
+    """Класс, представляющий производные цвета обложки.
+
+    Attributes:
+        average (:obj:`str`, optional): Средний цвет.
+        wave_text (:obj:`str`, optional): Цвет текста волны.
+        mini_player (:obj:`str`, optional): Цвет мини-плеера.
+        accent (:obj:`str`, optional): Акцентный цвет.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    average: Optional[str] = None
+    wave_text: Optional[str] = None
+    mini_player: Optional[str] = None
+    accent: Optional[str] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.average, self.wave_text, self.mini_player, self.accent)

--- a/yandex_music/pin/pin.py
+++ b/yandex_music/pin/pin.py
@@ -1,0 +1,50 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.pin.pin_data import PinData
+
+
+@model
+class Pin(YandexMusicModel):
+    """Класс, представляющий закреплённый элемент.
+
+    Note:
+        Известные значения поля `type`: `artist_item`, `album_item`, `playlist_item`, `wave_item`.
+
+    Attributes:
+        type (:obj:`str`): Тип закреплённого элемента.
+        data (:obj:`yandex_music.PinData`, optional): Данные закреплённого элемента.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    type: str
+    data: Optional['PinData'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.type, self.data)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['Pin']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.Pin`: Закреплённый элемент.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.pin.pin_data import PinData
+
+        cls_data['data'] = PinData.de_json(cls_data.get('data'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/pin/pin_data.py
+++ b/yandex_music/pin/pin_data.py
@@ -1,0 +1,66 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, ContentRestrictions, Cover, JSONType
+
+
+@model
+class PinData(YandexMusicModel):
+    """Класс, представляющий данные закреплённого элемента.
+
+    Note:
+        Для артистов используется поле `name`, для альбомов и плейлистов — `title`.
+
+        Поле `playlist_uuid` доступно только для плейлистов.
+
+        Поле `content_restrictions` может содержать информацию о доступности и ограничениях.
+
+    Attributes:
+        id (:obj:`int`, optional): Уникальный идентификатор (для артистов и альбомов).
+        uid (:obj:`int`, optional): Уникальный идентификатор пользователя (для плейлистов).
+        kind (:obj:`int`, optional): Номер плейлиста.
+        playlist_uuid (:obj:`str`, optional): UUID плейлиста.
+        name (:obj:`str`, optional): Имя артиста.
+        title (:obj:`str`, optional): Название альбома или плейлиста.
+        cover (:obj:`yandex_music.Cover`, optional): Обложка.
+        content_restrictions (:obj:`yandex_music.ContentRestrictions`, optional): Ограничения контента.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    id: Optional[int] = None
+    uid: Optional[int] = None
+    kind: Optional[int] = None
+    playlist_uuid: Optional[str] = None
+    name: Optional[str] = None
+    title: Optional[str] = None
+    cover: Optional['Cover'] = None
+    content_restrictions: Optional['ContentRestrictions'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.id, self.uid, self.kind, self.name, self.title)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['PinData']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.PinData`: Данные закреплённого элемента.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import ContentRestrictions, Cover
+
+        cls_data['cover'] = Cover.de_json(cls_data.get('cover'), client)
+        cls_data['content_restrictions'] = ContentRestrictions.de_json(cls_data.get('content_restrictions'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/utils/request.py
+++ b/yandex_music/utils/request.py
@@ -133,6 +133,68 @@ class Request(RequestBase):
 
         return None
 
+    def put(
+        self,
+        url: str,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: 'TimeoutType' = default_timeout,
+        **kwargs: Any,
+    ) -> Optional['JSONType']:
+        """Отправка PUT запроса.
+
+        Args:
+            url (:obj:`str`): Адрес для запроса.
+            json (:obj:`dict`): JSON тело запроса.
+            timeout (:obj:`int` | :obj:`float`): Используется как время ожидания ответа от сервера вместо указанного
+                при создании пула.
+            **kwargs: Произвольные ключевые аргументы для `requests.request`.
+
+        Returns:
+            :obj:`JSONType`: Обработанное тело ответа.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        result = self._request_wrapper(
+            'PUT', url, headers=self.headers, proxies=self.proxies, json=json, timeout=timeout, **kwargs
+        )
+        response = self._parse(result)
+        if response:
+            return response.get_result()
+
+        return None
+
+    def delete(
+        self,
+        url: str,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: 'TimeoutType' = default_timeout,
+        **kwargs: Any,
+    ) -> Optional['JSONType']:
+        """Отправка DELETE запроса.
+
+        Args:
+            url (:obj:`str`): Адрес для запроса.
+            json (:obj:`dict`): JSON тело запроса.
+            timeout (:obj:`int` | :obj:`float`): Используется как время ожидания ответа от сервера вместо указанного
+                при создании пула.
+            **kwargs: Произвольные ключевые аргументы для `requests.request`.
+
+        Returns:
+            :obj:`JSONType`: Обработанное тело ответа.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        result = self._request_wrapper(
+            'DELETE', url, headers=self.headers, proxies=self.proxies, json=json, timeout=timeout, **kwargs
+        )
+        response = self._parse(result)
+        if response:
+            return response.get_result()
+
+        return None
+
     def retrieve(self, url: str, timeout: 'TimeoutType' = default_timeout, **kwargs: Any) -> bytes:
         """Отправка GET запроса и получение содержимого без обработки (парсинга).
 

--- a/yandex_music/utils/request_async.py
+++ b/yandex_music/utils/request_async.py
@@ -154,6 +154,68 @@ class Request(RequestBase):
 
         return None
 
+    async def put(
+        self,
+        url: str,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: 'TimeoutType' = default_timeout,
+        **kwargs: Any,
+    ) -> Optional['JSONType']:
+        """Отправка PUT запроса.
+
+        Args:
+            url (:obj:`str`): Адрес для запроса.
+            json (:obj:`dict`): JSON тело запроса.
+            timeout (:obj:`int` | :obj:`float`): Используется как время ожидания ответа от сервера вместо указанного
+                при создании пула.
+            **kwargs: Произвольные ключевые аргументы для `aiohttp.request`.
+
+        Returns:
+            :obj:`JSONType`: Обработанное тело ответа.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        result = await self._request_wrapper(
+            'PUT', url, headers=self.headers, proxy=self.proxy_url, json=json, timeout=timeout, **kwargs
+        )
+        response = self._parse(result)
+        if response:
+            return response.get_result()
+
+        return None
+
+    async def delete(
+        self,
+        url: str,
+        json: Optional[Dict[str, Any]] = None,
+        timeout: 'TimeoutType' = default_timeout,
+        **kwargs: Any,
+    ) -> Optional['JSONType']:
+        """Отправка DELETE запроса.
+
+        Args:
+            url (:obj:`str`): Адрес для запроса.
+            json (:obj:`dict`): JSON тело запроса.
+            timeout (:obj:`int` | :obj:`float`): Используется как время ожидания ответа от сервера вместо указанного
+                при создании пула.
+            **kwargs: Произвольные ключевые аргументы для `aiohttp.request`.
+
+        Returns:
+            :obj:`JSONType`: Обработанное тело ответа.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        result = await self._request_wrapper(
+            'DELETE', url, headers=self.headers, proxy=self.proxy_url, json=json, timeout=timeout, **kwargs
+        )
+        response = self._parse(result)
+        if response:
+            return response.get_result()
+
+        return None
+
     async def retrieve(self, url: str, timeout: 'TimeoutType' = default_timeout, **kwargs: Any) -> bytes:
         """Отправка GET запроса и получение содержимого без обработки (парсинга).
 


### PR DESCRIPTION
Новые модели:
- ArtistLink — ссылки на страницы артиста
- ArtistConcerts — список концертов артиста
- Concert, ConcertMinPrice, ConcertCashback, ConcertEventInfo — концерты
- ContentRestrictions — ограничения контента
- CoverDerivedColors — производные цвета обложки
- Pin, PinData — закреплённые элементы

Новые методы клиента:
- artists_similar, artists_links, artists_also_albums, artists_discography_albums, artists_safe_direct_albums, artists_track_ids, artists_concerts
- pins, pin_album, unpin_album, pin_artist, unpin_artist, pin_playlist, unpin_playlist, pin_wave, unpin_wave
- PUT и DELETE методы в Request/RequestAsync

Новые поля в существующих моделях:
- Artist: disclaimers, content_restrictions
- Cover: color, derived_colors