### PR TITLE
Добавлены расширенные маршруты альбомов и выделен миксин albums.py

### DIFF
--- a/docs/source/yandex_music.album.album_trailer.rst
+++ b/docs/source/yandex_music.album.album_trailer.rst
@@ -1,0 +1,7 @@
+yandex\_music.album.album\_trailer
+==================================
+
+.. automodule:: yandex_music.album.album_trailer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.album.rst
+++ b/docs/source/yandex_music.album.rst
@@ -13,6 +13,8 @@ Submodules
    :maxdepth: 4
 
    yandex_music.album.album
+   yandex_music.album.album_trailer
    yandex_music.album.deprecation
    yandex_music.album.label
    yandex_music.album.track_position
+   yandex_music.album.trailer_info

--- a/docs/source/yandex_music.album.trailer_info.rst
+++ b/docs/source/yandex_music.album.trailer_info.rst
@@ -1,0 +1,7 @@
+yandex\_music.album.trailer\_info
+=================================
+
+.. automodule:: yandex_music.album.trailer_info
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.rst
+++ b/docs/source/yandex_music.rst
@@ -28,6 +28,7 @@ Subpackages
    yandex_music.supplement
    yandex_music.track
    yandex_music.utils
+   yandex_music.wave
 
 Submodules
 ----------

--- a/docs/source/yandex_music.wave.rst
+++ b/docs/source/yandex_music.wave.rst
@@ -1,0 +1,19 @@
+yandex\_music.wave
+==================
+
+.. automodule:: yandex_music.wave
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   yandex_music.wave.similar_entity_data
+   yandex_music.wave.similar_entity_item
+   yandex_music.wave.wave
+   yandex_music.wave.wave_agent
+   yandex_music.wave.wave_agent_entity

--- a/docs/source/yandex_music.wave.similar_entity_data.rst
+++ b/docs/source/yandex_music.wave.similar_entity_data.rst
@@ -1,0 +1,7 @@
+yandex\_music.wave.similar\_entity\_data
+========================================
+
+.. automodule:: yandex_music.wave.similar_entity_data
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.wave.similar_entity_item.rst
+++ b/docs/source/yandex_music.wave.similar_entity_item.rst
@@ -1,0 +1,7 @@
+yandex\_music.wave.similar\_entity\_item
+========================================
+
+.. automodule:: yandex_music.wave.similar_entity_item
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.wave.wave.rst
+++ b/docs/source/yandex_music.wave.wave.rst
@@ -1,0 +1,7 @@
+yandex\_music.wave.wave
+=======================
+
+.. automodule:: yandex_music.wave.wave
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.wave.wave_agent.rst
+++ b/docs/source/yandex_music.wave.wave_agent.rst
@@ -1,0 +1,7 @@
+yandex\_music.wave.wave\_agent
+==============================
+
+.. automodule:: yandex_music.wave.wave_agent
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.wave.wave_agent_entity.rst
+++ b/docs/source/yandex_music.wave.wave_agent_entity.rst
@@ -1,0 +1,7 @@
+yandex\_music.wave.wave\_agent\_entity
+======================================
+
+.. automodule:: yandex_music.wave.wave_agent_entity
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ from .test_account import TestAccount
 from .test_ad_params import TestAdParams
 from .test_album import TestAlbum
 from .test_album_event import TestAlbumEvent
+from .test_album_trailer import TestAlbumTrailer
 from .test_alert import TestAlert
 from .test_alert_button import TestAlertButton
 from .test_artist import TestArtist
@@ -85,6 +86,8 @@ from .test_settings import TestSettings
 from .test_shot import TestShot
 from .test_shot_data import TestShotData
 from .test_shot_type import TestShotType
+from .test_similar_entity_data import TestSimilarEntityData
+from .test_similar_entity_item import TestSimilarEntityItem
 from .test_station import TestStation
 from .test_station_data import TestStationData
 from .test_station_result import TestStationResult
@@ -101,8 +104,12 @@ from .test_track_position import TestTrackPosition
 from .test_track_short import TestTrackShort
 from .test_track_short_old import TestTrackShortOld
 from .test_track_with_ads import TestTrackWithAds
+from .test_trailer_info import TestTrailerInfo
 from .test_user import TestUser
 from .test_value import TestValue
 from .test_video import TestVideo
 from .test_video_supplement import TestVideoSupplement
 from .test_vinyl import TestVinyl
+from .test_wave import TestWave
+from .test_wave_agent import TestWaveAgent
+from .test_wave_agent_entity import TestWaveAgentEntity

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from yandex_music import (
     AdParams,
     Album,
     AlbumEvent,
+    AlbumTrailer,
     Alert,
     AlertButton,
     Artist,
@@ -88,6 +89,8 @@ from yandex_music import (
     Shot,
     ShotData,
     ShotType,
+    SimilarEntityData,
+    SimilarEntityItem,
     Station,
     StationData,
     StationResult,
@@ -103,11 +106,15 @@ from yandex_music import (
     TrackShort,
     TrackShortOld,
     TrackWithAds,
+    TrailerInfo,
     User,
     Value,
     Video,
     VideoSupplement,
     Vinyl,
+    Wave,
+    WaveAgent,
+    WaveAgentEntity,
 )
 
 from . import (
@@ -191,6 +198,7 @@ from . import (
     TestShot,
     TestShotData,
     TestShotType,
+    TestSimilarEntityItem,
     TestStation,
     TestStationData,
     TestStationResult,
@@ -206,11 +214,15 @@ from . import (
     TestTrackShort,
     TestTrackShortOld,
     TestTrackWithAds,
+    TestTrailerInfo,
     TestUser,
     TestValue,
     TestVideo,
     TestVideoSupplement,
     TestVinyl,
+    TestWave,
+    TestWaveAgent,
+    TestWaveAgentEntity,
 )
 
 
@@ -1472,6 +1484,59 @@ def pin_album(pin_data_album):
 @pytest.fixture(scope='session')
 def pin_playlist(pin_data_playlist):
     return Pin(type=TestPin.type_playlist, data=pin_data_playlist)
+
+
+@pytest.fixture(scope='session')
+def wave():
+    return Wave(
+        name=TestWave.name,
+        description=TestWave.description,
+        seeds=TestWave.seeds,
+    )
+
+
+@pytest.fixture(scope='session')
+def wave_agent_entity():
+    return WaveAgentEntity(type=TestWaveAgentEntity.type)
+
+
+@pytest.fixture(scope='session')
+def wave_agent(cover, wave_agent_entity):
+    return WaveAgent(
+        animation_uri=TestWaveAgent.animation_uri,
+        cover=cover,
+        entity=wave_agent_entity,
+    )
+
+
+@pytest.fixture(scope='session')
+def similar_entity_data(wave, wave_agent):
+    return SimilarEntityData(wave=wave, agent=wave_agent)
+
+
+@pytest.fixture(scope='session')
+def similar_entity_item(similar_entity_data):
+    return SimilarEntityItem(
+        type=TestSimilarEntityItem.type,
+        data=similar_entity_data,
+    )
+
+
+@pytest.fixture(scope='session')
+def trailer_info(track):
+    return TrailerInfo(
+        title=TestTrailerInfo.title,
+        tracks=[track],
+    )
+
+
+@pytest.fixture(scope='session')
+def album_trailer(album, artist, trailer_info):
+    return AlbumTrailer(
+        album=album,
+        artists=[artist],
+        trailer=trailer_info,
+    )
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_album_trailer.py
+++ b/tests/test_album_trailer.py
@@ -1,0 +1,32 @@
+from yandex_music import AlbumTrailer
+
+
+class TestAlbumTrailer:
+    def test_expected_values(self, album_trailer, album, artist, trailer_info):
+        assert album_trailer.album == album
+        assert album_trailer.artists == [artist]
+        assert album_trailer.trailer == trailer_info
+
+    def test_de_json_none(self, client):
+        assert AlbumTrailer.de_json({}, client) is None
+
+    def test_de_json_all(self, client, album, artist, trailer_info):
+        json_dict = {
+            'album': album.to_dict(),
+            'artists': [artist.to_dict()],
+            'trailer': trailer_info.to_dict(),
+        }
+        trailer = AlbumTrailer.de_json(json_dict, client)
+
+        assert trailer.album == album
+        assert trailer.artists == [artist]
+        assert trailer.trailer == trailer_info
+
+    def test_equality(self, album, trailer_info):
+        a = AlbumTrailer(album=album, trailer=trailer_info)
+        b = AlbumTrailer(album=None, trailer=trailer_info)
+        c = AlbumTrailer(album=album, trailer=trailer_info)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_similar_entity_data.py
+++ b/tests/test_similar_entity_data.py
@@ -1,0 +1,29 @@
+from yandex_music import SimilarEntityData
+
+
+class TestSimilarEntityData:
+    def test_expected_values(self, similar_entity_data, wave, wave_agent):
+        assert similar_entity_data.wave == wave
+        assert similar_entity_data.agent == wave_agent
+
+    def test_de_json_none(self, client):
+        assert SimilarEntityData.de_json({}, client) is None
+
+    def test_de_json_all(self, client, wave, wave_agent):
+        json_dict = {
+            'wave': wave.to_dict(),
+            'agent': wave_agent.to_dict(),
+        }
+        data = SimilarEntityData.de_json(json_dict, client)
+
+        assert data.wave == wave
+        assert data.agent == wave_agent
+
+    def test_equality(self, wave, wave_agent):
+        a = SimilarEntityData(wave=wave, agent=wave_agent)
+        b = SimilarEntityData(wave=None, agent=wave_agent)
+        c = SimilarEntityData(wave=wave, agent=wave_agent)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_similar_entity_item.py
+++ b/tests/test_similar_entity_item.py
@@ -1,0 +1,43 @@
+from yandex_music import SimilarEntityItem
+
+
+class TestSimilarEntityItem:
+    type = 'wave_agent_item'
+
+    def test_expected_values(self, similar_entity_item, similar_entity_data):
+        assert similar_entity_item.type == self.type
+        assert similar_entity_item.data == similar_entity_data
+
+    def test_de_json_none(self, client):
+        assert SimilarEntityItem.de_json({}, client) is None
+
+    def test_de_json_all(self, client, similar_entity_data):
+        json_dict = {
+            'type': self.type,
+            'data': similar_entity_data.to_dict(),
+        }
+        item = SimilarEntityItem.de_json(json_dict, client)
+
+        assert item.type == self.type
+        assert item.data == similar_entity_data
+
+    def test_de_list(self, client, similar_entity_data):
+        json_list = [
+            {
+                'type': self.type,
+                'data': similar_entity_data.to_dict(),
+            },
+        ]
+        items = SimilarEntityItem.de_list(json_list, client)
+
+        assert len(items) == 1
+        assert items[0].type == self.type
+
+    def test_equality(self, similar_entity_data):
+        a = SimilarEntityItem(type=self.type, data=similar_entity_data)
+        b = SimilarEntityItem(type='other', data=similar_entity_data)
+        c = SimilarEntityItem(type=self.type, data=similar_entity_data)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_trailer_info.py
+++ b/tests/test_trailer_info.py
@@ -1,0 +1,31 @@
+from yandex_music import TrailerInfo
+
+
+class TestTrailerInfo:
+    title = 'Трейлер альбома'
+
+    def test_expected_values(self, trailer_info, track):
+        assert trailer_info.title == self.title
+        assert trailer_info.tracks == [track]
+
+    def test_de_json_none(self, client):
+        assert TrailerInfo.de_json({}, client) is None
+
+    def test_de_json_all(self, client, track):
+        json_dict = {
+            'title': self.title,
+            'tracks': [track.to_dict()],
+        }
+        info = TrailerInfo.de_json(json_dict, client)
+
+        assert info.title == self.title
+        assert info.tracks == [track]
+
+    def test_equality(self, track):
+        a = TrailerInfo(title=self.title, tracks=[track])
+        b = TrailerInfo(title='Other', tracks=[track])
+        c = TrailerInfo(title=self.title, tracks=[track])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_wave.py
+++ b/tests/test_wave.py
@@ -1,0 +1,36 @@
+from yandex_music import Wave
+
+
+class TestWave:
+    name = 'Test Wave'
+    description = 'Моя волна по альбому'
+    seeds = ['album:12345']
+
+    def test_expected_values(self, wave):
+        assert wave.name == self.name
+        assert wave.description == self.description
+        assert wave.seeds == self.seeds
+
+    def test_de_json_none(self, client):
+        assert Wave.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'name': self.name,
+            'description': self.description,
+            'seeds': self.seeds,
+        }
+        wave = Wave.de_json(json_dict, client)
+
+        assert wave.name == self.name
+        assert wave.description == self.description
+        assert wave.seeds == self.seeds
+
+    def test_equality(self):
+        a = Wave(name=self.name, seeds=self.seeds)
+        b = Wave(name='Other', seeds=['artist:999'])
+        c = Wave(name=self.name, seeds=self.seeds)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_wave_agent.py
+++ b/tests/test_wave_agent.py
@@ -1,0 +1,34 @@
+from yandex_music import WaveAgent
+
+
+class TestWaveAgent:
+    animation_uri = 'https://example.com/animation'
+
+    def test_expected_values(self, wave_agent, cover, wave_agent_entity):
+        assert wave_agent.animation_uri == self.animation_uri
+        assert wave_agent.cover == cover
+        assert wave_agent.entity == wave_agent_entity
+
+    def test_de_json_none(self, client):
+        assert WaveAgent.de_json({}, client) is None
+
+    def test_de_json_all(self, client, cover, wave_agent_entity):
+        json_dict = {
+            'animationUri': self.animation_uri,
+            'cover': cover.to_dict(),
+            'entity': wave_agent_entity.to_dict(),
+        }
+        agent = WaveAgent.de_json(json_dict, client)
+
+        assert agent.animation_uri == self.animation_uri
+        assert agent.cover == cover
+        assert agent.entity == wave_agent_entity
+
+    def test_equality(self, cover):
+        a = WaveAgent(animation_uri=self.animation_uri, cover=cover)
+        b = WaveAgent(animation_uri='https://other.com', cover=cover)
+        c = WaveAgent(animation_uri=self.animation_uri, cover=cover)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_wave_agent_entity.py
+++ b/tests/test_wave_agent_entity.py
@@ -1,0 +1,26 @@
+from yandex_music import WaveAgentEntity
+
+
+class TestWaveAgentEntity:
+    type = 'album'
+
+    def test_expected_values(self, wave_agent_entity):
+        assert wave_agent_entity.type == self.type
+
+    def test_de_json_none(self, client):
+        assert WaveAgentEntity.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {'type': self.type}
+        entity = WaveAgentEntity.de_json(json_dict, client)
+
+        assert entity.type == self.type
+
+    def test_equality(self):
+        a = WaveAgentEntity(type=self.type)
+        b = WaveAgentEntity(type='artist')
+        c = WaveAgentEntity(type=self.type)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/yandex_music/__init__.py
+++ b/yandex_music/__init__.py
@@ -26,8 +26,10 @@ from .account.passport_phone import PassportPhone
 from .account.permissions import Permissions
 
 from .album.album import Album
+from .album.album_trailer import AlbumTrailer
 from .album.label import Label
 from .album.track_position import TrackPosition
+from .album.trailer_info import TrailerInfo
 from .album.deprecation import Deprecation
 
 from .artist.artist import Artist
@@ -141,6 +143,12 @@ from .queue.context import Context
 from .queue.queue import Queue
 from .queue.queue_item import QueueItem
 
+from .wave.wave import Wave
+from .wave.wave_agent_entity import WaveAgentEntity
+from .wave.wave_agent import WaveAgent
+from .wave.similar_entity_data import SimilarEntityData
+from .wave.similar_entity_item import SimilarEntityItem
+
 from .content_restrictions import ContentRestrictions
 from .like import Like
 from .pager import Pager
@@ -161,6 +169,7 @@ __all__ = [
     'AdParams',
     'Album',
     'AlbumEvent',
+    'AlbumTrailer',
     'Alert',
     'AlertButton',
     'Artist',
@@ -265,6 +274,8 @@ __all__ = [
     'ShotData',
     'ShotEvent',
     'ShotType',
+    'SimilarEntityData',
+    'SimilarEntityItem',
     'SimilarTracks',
     'Station',
     'StationData',
@@ -286,12 +297,16 @@ __all__ = [
     'TrackShortOld',
     'TrackWithAds',
     'TracksList',
+    'TrailerInfo',
     'User',
     'UserSettings',
     'Value',
     'Video',
     'VideoSupplement',
     'Vinyl',
+    'Wave',
+    'WaveAgent',
+    'WaveAgentEntity',
     'YandexMusicModel',
     'YandexMusicObject',
     '__copyright__',

--- a/yandex_music/_client/albums.py
+++ b/yandex_music/_client/albums.py
@@ -1,0 +1,117 @@
+###############################################################################################
+# THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/albums.py. DON'T EDIT IT BY HANDS #
+###############################################################################################
+
+from typing import TYPE_CHECKING, Any, List, Optional, Union
+
+from yandex_music import Album, AlbumTrailer, SimilarEntityItem
+from yandex_music._client import log
+from yandex_music._client_base import ClientBase, is_dict
+
+if TYPE_CHECKING:
+    from yandex_music.utils.request import Request
+
+
+class AlbumsMixin(ClientBase):
+    """Миксин для методов, связанных с альбомами."""
+
+    _request: 'Request'
+
+    @log
+    def albums_with_tracks(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[Album]:
+        """Получение альбома по его уникальному идентификатору вместе с треками.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`yandex_music.Album` | :obj:`None`: Альбом или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/albums/{album_id}/with-tracks'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return Album.de_json(result, self)
+
+    @log
+    def albums_disclaimer(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[str]:
+        """Получение дисклеймера альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`str` | :obj:`None`: Текст дисклеймера или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/albums/{album_id}/disclaimer'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        if is_dict(result):
+            return result.get('text')
+        return None
+
+    @log
+    def albums_similar_entities(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> List[SimilarEntityItem]:
+        """Получение похожих сущностей для альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`yandex_music.SimilarEntityItem`: Список похожих сущностей.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/albums/{album_id}/similar-entities'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        if is_dict(result):
+            return list(SimilarEntityItem.de_list(result.get('items'), self))
+        return []
+
+    @log
+    def albums_trailer(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[AlbumTrailer]:
+        """Получение трейлера альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.AlbumTrailer` | :obj:`None`: Трейлер альбома или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/albums/{album_id}/trailer'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return AlbumTrailer.de_json(result, self)
+
+    # camelCase псевдонимы
+
+    #: Псевдоним для :attr:`albums_with_tracks`
+    albumsWithTracks = albums_with_tracks
+    #: Псевдоним для :attr:`albums_disclaimer`
+    albumsDisclaimer = albums_disclaimer
+    #: Псевдоним для :attr:`albums_similar_entities`
+    albumsSimilarEntities = albums_similar_entities
+    #: Псевдоним для :attr:`albums_trailer`
+    albumsTrailer = albums_trailer

--- a/yandex_music/_client/tracks.py
+++ b/yandex_music/_client/tracks.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from yandex_music import Album, DownloadInfo, ShotEvent, SimilarTracks, Supplement, TrackLyrics
+from yandex_music import DownloadInfo, ShotEvent, SimilarTracks, Supplement, TrackLyrics
 from yandex_music._client import log
 from yandex_music._client_base import ClientBase, is_dict
 from yandex_music.utils.sign_request import get_sign_request
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class TracksMixin(ClientBase):
-    """Миксин для методов, связанных с треками и альбомами."""
+    """Миксин для методов, связанных с треками."""
 
     _request: 'Request'
 
@@ -202,27 +202,6 @@ class TracksMixin(ClientBase):
         return result == 'ok'
 
     @log
-    def albums_with_tracks(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[Album]:
-        """Получение альбома по его уникальному идентификатору вместе с треками.
-
-        Args:
-            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
-            *args: Произвольные аргументы (будут переданы в запрос).
-            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
-
-        Returns:
-            :obj:`list` из :obj:`yandex_music.Album` | :obj:`None`: Альбом или :obj:`None`.
-
-        Raises:
-            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
-        """
-        url = f'{self.base_url}/albums/{album_id}/with-tracks'
-
-        result = self._request.get(url, *args, **kwargs)
-
-        return Album.de_json(result, self)
-
-    @log
     def after_track(
         self,
         next_track_id: Union[str, int],
@@ -295,7 +274,5 @@ class TracksMixin(ClientBase):
     tracksSimilar = tracks_similar
     #: Псевдоним для :attr:`play_audio`
     playAudio = play_audio
-    #: Псевдоним для :attr:`albums_with_tracks`
-    albumsWithTracks = albums_with_tracks
     #: Псевдоним для :attr:`after_track`
     afterTrack = after_track

--- a/yandex_music/_client_async/albums.py
+++ b/yandex_music/_client_async/albums.py
@@ -1,0 +1,115 @@
+from typing import TYPE_CHECKING, Any, List, Optional, Union
+
+from yandex_music import Album, AlbumTrailer, SimilarEntityItem
+from yandex_music._client_async import log
+from yandex_music._client_base import ClientBase, is_dict
+
+if TYPE_CHECKING:
+    from yandex_music.utils.request_async import Request
+
+
+class AlbumsMixin(ClientBase):
+    """Миксин для методов, связанных с альбомами."""
+
+    _request: 'Request'
+
+    @log
+    async def albums_with_tracks(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[Album]:
+        """Получение альбома по его уникальному идентификатору вместе с треками.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`yandex_music.Album` | :obj:`None`: Альбом или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/albums/{album_id}/with-tracks'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return Album.de_json(result, self)
+
+    @log
+    async def albums_disclaimer(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[str]:
+        """Получение дисклеймера альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`str` | :obj:`None`: Текст дисклеймера или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/albums/{album_id}/disclaimer'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        if is_dict(result):
+            return result.get('text')
+        return None
+
+    @log
+    async def albums_similar_entities(
+        self, album_id: Union[str, int], *args: Any, **kwargs: Any
+    ) -> List[SimilarEntityItem]:
+        """Получение похожих сущностей для альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`yandex_music.SimilarEntityItem`: Список похожих сущностей.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/albums/{album_id}/similar-entities'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        if is_dict(result):
+            return list(SimilarEntityItem.de_list(result.get('items'), self))
+        return []
+
+    @log
+    async def albums_trailer(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[AlbumTrailer]:
+        """Получение трейлера альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.AlbumTrailer` | :obj:`None`: Трейлер альбома или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/albums/{album_id}/trailer'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return AlbumTrailer.de_json(result, self)
+
+    # camelCase псевдонимы
+
+    #: Псевдоним для :attr:`albums_with_tracks`
+    albumsWithTracks = albums_with_tracks
+    #: Псевдоним для :attr:`albums_disclaimer`
+    albumsDisclaimer = albums_disclaimer
+    #: Псевдоним для :attr:`albums_similar_entities`
+    albumsSimilarEntities = albums_similar_entities
+    #: Псевдоним для :attr:`albums_trailer`
+    albumsTrailer = albums_trailer

--- a/yandex_music/_client_async/tracks.py
+++ b/yandex_music/_client_async/tracks.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from yandex_music import Album, DownloadInfo, ShotEvent, SimilarTracks, Supplement, TrackLyrics
+from yandex_music import DownloadInfo, ShotEvent, SimilarTracks, Supplement, TrackLyrics
 from yandex_music._client_async import log
 from yandex_music._client_base import ClientBase, is_dict
 from yandex_music.utils.sign_request import get_sign_request
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class TracksMixin(ClientBase):
-    """Миксин для методов, связанных с треками и альбомами."""
+    """Миксин для методов, связанных с треками."""
 
     _request: 'Request'
 
@@ -198,27 +198,6 @@ class TracksMixin(ClientBase):
         return result == 'ok'
 
     @log
-    async def albums_with_tracks(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[Album]:
-        """Получение альбома по его уникальному идентификатору вместе с треками.
-
-        Args:
-            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
-            *args: Произвольные аргументы (будут переданы в запрос).
-            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
-
-        Returns:
-            :obj:`list` из :obj:`yandex_music.Album` | :obj:`None`: Альбом или :obj:`None`.
-
-        Raises:
-            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
-        """
-        url = f'{self.base_url}/albums/{album_id}/with-tracks'
-
-        result = await self._request.get(url, *args, **kwargs)
-
-        return Album.de_json(result, self)
-
-    @log
     async def after_track(
         self,
         next_track_id: Union[str, int],
@@ -291,7 +270,5 @@ class TracksMixin(ClientBase):
     tracksSimilar = tracks_similar
     #: Псевдоним для :attr:`play_audio`
     playAudio = play_audio
-    #: Псевдоним для :attr:`albums_with_tracks`
-    albumsWithTracks = albums_with_tracks
     #: Псевдоним для :attr:`after_track`
     afterTrack = after_track

--- a/yandex_music/album/album_trailer.py
+++ b/yandex_music/album/album_trailer.py
@@ -1,0 +1,54 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.album.album import Album
+    from yandex_music.album.trailer_info import TrailerInfo
+    from yandex_music.artist.artist import Artist
+
+
+@model
+class AlbumTrailer(YandexMusicModel):
+    """Класс, представляющий трейлер альбома.
+
+    Attributes:
+        album (:obj:`yandex_music.Album`, optional): Альбом.
+        artists (:obj:`list` из :obj:`yandex_music.Artist`, optional): Список артистов.
+        trailer (:obj:`yandex_music.TrailerInfo`, optional): Информация о трейлере.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    album: Optional['Album'] = None
+    artists: Optional[List['Artist']] = None
+    trailer: Optional['TrailerInfo'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.album, self.trailer)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['AlbumTrailer']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.AlbumTrailer`: Трейлер альбома.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Album, Artist
+        from yandex_music.album.trailer_info import TrailerInfo
+
+        cls_data['album'] = Album.de_json(cls_data.get('album'), client)
+        cls_data['artists'] = Artist.de_list(cls_data.get('artists'), client)
+        cls_data['trailer'] = TrailerInfo.de_json(cls_data.get('trailer'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/album/trailer_info.py
+++ b/yandex_music/album/trailer_info.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.track.track import Track
+
+
+@model
+class TrailerInfo(YandexMusicModel):
+    """Класс, представляющий информацию о трейлере альбома.
+
+    Attributes:
+        title (:obj:`str`, optional): Заголовок трейлера.
+        tracks (:obj:`list` из :obj:`yandex_music.Track`, optional): Список треков трейлера.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    title: Optional[str] = None
+    tracks: Optional[List['Track']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.title, self.tracks)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['TrailerInfo']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.TrailerInfo`: Информация о трейлере альбома.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Track
+
+        cls_data['tracks'] = Track.de_list(cls_data.get('tracks'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/client.py
+++ b/yandex_music/client.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from yandex_music import Status, YandexMusicObject, __copyright__, __license__, __version__
 from yandex_music._client.account import AccountMixin
+from yandex_music._client.albums import AlbumsMixin
 from yandex_music._client.artists import ArtistsMixin
 from yandex_music._client.batch import BatchMixin
 from yandex_music._client.landing import LandingMixin
@@ -24,6 +25,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 class Client(
     AccountMixin,
+    AlbumsMixin,
     LandingMixin,
     TracksMixin,
     SearchMixin,

--- a/yandex_music/client_async.py
+++ b/yandex_music/client_async.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from yandex_music import Status, YandexMusicObject, __copyright__, __license__, __version__
 from yandex_music._client_async.account import AccountMixin
+from yandex_music._client_async.albums import AlbumsMixin
 from yandex_music._client_async.artists import ArtistsMixin
 from yandex_music._client_async.batch import BatchMixin
 from yandex_music._client_async.landing import LandingMixin
@@ -20,6 +21,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 class ClientAsync(
     AccountMixin,
+    AlbumsMixin,
     LandingMixin,
     TracksMixin,
     SearchMixin,

--- a/yandex_music/wave/similar_entity_data.py
+++ b/yandex_music/wave/similar_entity_data.py
@@ -1,0 +1,50 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.wave.wave import Wave
+    from yandex_music.wave.wave_agent import WaveAgent
+
+
+@model
+class SimilarEntityData(YandexMusicModel):
+    """Класс, представляющий данные похожей сущности.
+
+    Attributes:
+        wave (:obj:`yandex_music.Wave`, optional): Волна.
+        agent (:obj:`yandex_music.WaveAgent`, optional): Агент волны.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    wave: Optional['Wave'] = None
+    agent: Optional['WaveAgent'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.wave, self.agent)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['SimilarEntityData']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.SimilarEntityData`: Данные похожей сущности.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.wave.wave import Wave
+        from yandex_music.wave.wave_agent import WaveAgent
+
+        cls_data['wave'] = Wave.de_json(cls_data.get('wave'), client)
+        cls_data['agent'] = WaveAgent.de_json(cls_data.get('agent'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/wave/similar_entity_item.py
+++ b/yandex_music/wave/similar_entity_item.py
@@ -1,0 +1,50 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.wave.similar_entity_data import SimilarEntityData
+
+
+@model
+class SimilarEntityItem(YandexMusicModel):
+    """Класс, представляющий элемент списка похожих сущностей.
+
+    Note:
+        Известные значения поля `type`: ``wave_agent_item``.
+
+    Attributes:
+        type (:obj:`str`, optional): Тип элемента.
+        data (:obj:`yandex_music.SimilarEntityData`, optional): Данные элемента.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    type: Optional[str] = None
+    data: Optional['SimilarEntityData'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.type, self.data)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['SimilarEntityItem']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.SimilarEntityItem`: Элемент списка похожих сущностей.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.wave.similar_entity_data import SimilarEntityData
+
+        cls_data['data'] = SimilarEntityData.de_json(cls_data.get('data'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/wave/wave.py
+++ b/yandex_music/wave/wave.py
@@ -1,0 +1,27 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class Wave(YandexMusicModel):
+    """Класс, представляющий волну (персональную радиостанцию).
+
+    Attributes:
+        name (:obj:`str`, optional): Название волны.
+        description (:obj:`str`, optional): Описание волны.
+        seeds (:obj:`list` из :obj:`str`, optional): Список сидов волны (например, ``album:12345``).
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    seeds: Optional[List[str]] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.name, self.seeds)

--- a/yandex_music/wave/wave_agent.py
+++ b/yandex_music/wave/wave_agent.py
@@ -1,0 +1,51 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, Cover, JSONType
+    from yandex_music.wave.wave_agent_entity import WaveAgentEntity
+
+
+@model
+class WaveAgent(YandexMusicModel):
+    """Класс, представляющий агента волны.
+
+    Attributes:
+        animation_uri (:obj:`str`, optional): URI анимации агента.
+        cover (:obj:`yandex_music.Cover`, optional): Обложка агента.
+        entity (:obj:`yandex_music.WaveAgentEntity`, optional): Сущность, связанная с агентом.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    animation_uri: Optional[str] = None
+    cover: Optional['Cover'] = None
+    entity: Optional['WaveAgentEntity'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.animation_uri, self.cover)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['WaveAgent']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.WaveAgent`: Агент волны.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Cover
+        from yandex_music.wave.wave_agent_entity import WaveAgentEntity
+
+        cls_data['cover'] = Cover.de_json(cls_data.get('cover'), client)
+        cls_data['entity'] = WaveAgentEntity.de_json(cls_data.get('entity'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/wave/wave_agent_entity.py
+++ b/yandex_music/wave/wave_agent_entity.py
@@ -1,0 +1,26 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class WaveAgentEntity(YandexMusicModel):
+    """Класс, представляющий сущность агента волны.
+
+    Note:
+        Известные значения поля `type`: ``album``, ``artist``.
+
+    Attributes:
+        type (:obj:`str`, optional): Тип сущности.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    type: Optional[str] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.type,)


### PR DESCRIPTION
Новый миксин AlbumsMixin (albums.py):
- albums_with_tracks (перенесён из TracksMixin)
- albums_disclaimer — GET /albums/:albumId/disclaimer
- albums_similar_entities — GET /albums/:albumId/similar-entities
- albums_trailer — GET /albums/:albumId/trailer

Новые модели:
- AlbumTrailer, TrailerInfo (yandex_music/album/)
- Wave, WaveAgent, WaveAgentEntity, SimilarEntityData, SimilarEntityItem (yandex_music/wave/)