### PR TITLE
Добавлены расширенные маршруты треков, модель дисклеймера и рефакторинг возвращаемых типов

### DIFF
--- a/docs/source/yandex_music.album.album_similar_entities.rst
+++ b/docs/source/yandex_music.album.album_similar_entities.rst
@@ -1,0 +1,7 @@
+yandex\_music.album.album\_similar\_entities
+============================================
+
+.. automodule:: yandex_music.album.album_similar_entities
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.album.rst
+++ b/docs/source/yandex_music.album.rst
@@ -13,6 +13,7 @@ Submodules
    :maxdepth: 4
 
    yandex_music.album.album
+   yandex_music.album.album_similar_entities
    yandex_music.album.album_trailer
    yandex_music.album.deprecation
    yandex_music.album.label

--- a/docs/source/yandex_music.artist.artist_links.rst
+++ b/docs/source/yandex_music.artist.artist_links.rst
@@ -1,0 +1,7 @@
+yandex\_music.artist.artist\_links
+==================================
+
+.. automodule:: yandex_music.artist.artist_links
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.artist.artist_similar.rst
+++ b/docs/source/yandex_music.artist.artist_similar.rst
@@ -1,0 +1,7 @@
+yandex\_music.artist.artist\_similar
+====================================
+
+.. automodule:: yandex_music.artist.artist_similar
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.artist.rst
+++ b/docs/source/yandex_music.artist.rst
@@ -15,6 +15,8 @@ Submodules
    yandex_music.artist.artist
    yandex_music.artist.artist_albums
    yandex_music.artist.artist_link
+   yandex_music.artist.artist_links
+   yandex_music.artist.artist_similar
    yandex_music.artist.artist_tracks
    yandex_music.artist.brief_info
    yandex_music.artist.counts

--- a/docs/source/yandex_music.disclaimer.rst
+++ b/docs/source/yandex_music.disclaimer.rst
@@ -1,0 +1,7 @@
+yandex\_music.disclaimer
+========================
+
+.. automodule:: yandex_music.disclaimer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.foreign_agent.rst
+++ b/docs/source/yandex_music.foreign_agent.rst
@@ -1,0 +1,7 @@
+yandex\_music.foreign\_agent
+============================
+
+.. automodule:: yandex_music.foreign_agent
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.pin.pins_list.rst
+++ b/docs/source/yandex_music.pin.pins_list.rst
@@ -1,0 +1,7 @@
+yandex\_music.pin.pins\_list
+============================
+
+.. automodule:: yandex_music.pin.pins_list
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.pin.rst
+++ b/docs/source/yandex_music.pin.rst
@@ -14,3 +14,4 @@ Submodules
 
    yandex_music.pin.pin
    yandex_music.pin.pin_data
+   yandex_music.pin.pins_list

--- a/docs/source/yandex_music.rst
+++ b/docs/source/yandex_music.rst
@@ -42,9 +42,11 @@ Submodules
    yandex_music.content_restrictions
    yandex_music.cover
    yandex_music.cover_derived_colors
+   yandex_music.disclaimer
    yandex_music.download_info
    yandex_music.exceptions
    yandex_music.experiments
+   yandex_music.foreign_agent
    yandex_music.icon
    yandex_music.invocation_info
    yandex_music.like

--- a/docs/source/yandex_music.track.fade.rst
+++ b/docs/source/yandex_music.track.fade.rst
@@ -1,0 +1,7 @@
+yandex\_music.track.fade
+========================
+
+.. automodule:: yandex_music.track.fade
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.track.rst
+++ b/docs/source/yandex_music.track.rst
@@ -12,6 +12,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   yandex_music.track.fade
    yandex_music.track.licence_text_part
    yandex_music.track.lyrics_info
    yandex_music.track.lyrics_major
@@ -20,6 +21,11 @@ Submodules
    yandex_music.track.normalization
    yandex_music.track.poetry_lover_match
    yandex_music.track.r128
+   yandex_music.track.smart_preview_params
    yandex_music.track.track
+   yandex_music.track.track_credit
+   yandex_music.track.track_credits
+   yandex_music.track.track_full_info
    yandex_music.track.track_lyrics
+   yandex_music.track.track_trailer
    yandex_music.track.tracks_similar

--- a/docs/source/yandex_music.track.smart_preview_params.rst
+++ b/docs/source/yandex_music.track.smart_preview_params.rst
@@ -1,0 +1,7 @@
+yandex\_music.track.smart\_preview\_params
+==========================================
+
+.. automodule:: yandex_music.track.smart_preview_params
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.track.track_credit.rst
+++ b/docs/source/yandex_music.track.track_credit.rst
@@ -1,0 +1,7 @@
+yandex\_music.track.track\_credit
+=================================
+
+.. automodule:: yandex_music.track.track_credit
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.track.track_credits.rst
+++ b/docs/source/yandex_music.track.track_credits.rst
@@ -1,0 +1,7 @@
+yandex\_music.track.track\_credits
+==================================
+
+.. automodule:: yandex_music.track.track_credits
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.track.track_full_info.rst
+++ b/docs/source/yandex_music.track.track_full_info.rst
@@ -1,0 +1,7 @@
+yandex\_music.track.track\_full\_info
+=====================================
+
+.. automodule:: yandex_music.track.track_full_info
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.track.track_trailer.rst
+++ b/docs/source/yandex_music.track.track_trailer.rst
@@ -1,0 +1,7 @@
+yandex\_music.track.track\_trailer
+==================================
+
+.. automodule:: yandex_music.track.track_trailer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ from .test_account import TestAccount
 from .test_ad_params import TestAdParams
 from .test_album import TestAlbum
 from .test_album_event import TestAlbumEvent
+from .test_album_similar_entities import TestAlbumSimilarEntities
 from .test_album_trailer import TestAlbumTrailer
 from .test_alert import TestAlert
 from .test_alert_button import TestAlertButton
@@ -9,6 +10,8 @@ from .test_artist import TestArtist
 from .test_artist_concerts import TestArtistConcerts
 from .test_artist_event import TestArtistEvent
 from .test_artist_link import TestArtistLink
+from .test_artist_links import TestArtistLinks
+from .test_artist_similar import TestArtistSimilar
 from .test_auto_renewable import TestAutoRenewable
 from .test_best import TestBest
 from .test_block import TestBlock
@@ -34,9 +37,12 @@ from .test_day import TestDay
 from .test_deactivation import TestDeactivation
 from .test_deprecation import TestDeprecation
 from .test_description import TestDescription
+from .test_disclaimer import TestDisclaimer
 from .test_discrete_scale import TestDiscreteScale
 from .test_enum import TestEnum
 from .test_event import TestEvent
+from .test_fade import TestFade
+from .test_foreign_agent import TestForeignAgent
 from .test_generated_playlist import TestGeneratedPlaylist
 from .test_genre import TestGenre
 from .test_icon import TestIcon
@@ -63,6 +69,7 @@ from .test_permissions import TestPermissions
 from .test_personal_playlists_data import TestPersonalPlaylistsData
 from .test_pin import TestPin
 from .test_pin_data import TestPinData
+from .test_pins_list import TestPinsList
 from .test_play_context import TestPlayContext
 from .test_play_contexts_data import TestPlayContextsData
 from .test_play_counter import TestPlayCounter
@@ -88,6 +95,7 @@ from .test_shot_data import TestShotData
 from .test_shot_type import TestShotType
 from .test_similar_entity_data import TestSimilarEntityData
 from .test_similar_entity_item import TestSimilarEntityItem
+from .test_smart_preview_params import TestSmartPreviewParams
 from .test_station import TestStation
 from .test_station_data import TestStationData
 from .test_station_result import TestStationResult
@@ -98,11 +106,15 @@ from .test_suggestions import TestSuggestions
 from .test_tag import TestTag
 from .test_title import TestTitle
 from .test_track import TestTrack
+from .test_track_credit import TestTrackCredit
+from .test_track_credits import TestTrackCredits
+from .test_track_full_info import TestTrackFullInfo
 from .test_track_id import TestTrackId
 from .test_track_lyrics import TestTrackLyrics
 from .test_track_position import TestTrackPosition
 from .test_track_short import TestTrackShort
 from .test_track_short_old import TestTrackShortOld
+from .test_track_trailer import TestTrackTrailer
 from .test_track_with_ads import TestTrackWithAds
 from .test_trailer_info import TestTrailerInfo
 from .test_user import TestUser

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from yandex_music import (
     AdParams,
     Album,
     AlbumEvent,
+    AlbumSimilarEntities,
     AlbumTrailer,
     Alert,
     AlertButton,
@@ -13,6 +14,8 @@ from yandex_music import (
     ArtistConcerts,
     ArtistEvent,
     ArtistLink,
+    ArtistLinks,
+    ArtistSimilar,
     AutoRenewable,
     Best,
     Block,
@@ -40,9 +43,12 @@ from yandex_music import (
     Deactivation,
     Deprecation,
     Description,
+    Disclaimer,
     DiscreteScale,
     Enum,
     Event,
+    Fade,
+    ForeignAgent,
     GeneratedPlaylist,
     Icon,
     Id,
@@ -68,6 +74,7 @@ from yandex_music import (
     PersonalPlaylistsData,
     Pin,
     PinData,
+    PinsList,
     PlayContext,
     PlayContextsData,
     PlayCounter,
@@ -91,6 +98,7 @@ from yandex_music import (
     ShotType,
     SimilarEntityData,
     SimilarEntityItem,
+    SmartPreviewParams,
     Station,
     StationData,
     StationResult,
@@ -100,11 +108,15 @@ from yandex_music import (
     Tag,
     Title,
     Track,
+    TrackCredit,
+    TrackCredits,
+    TrackFullInfo,
     TrackId,
     TrackLyrics,
     TrackPosition,
     TrackShort,
     TrackShortOld,
+    TrackTrailer,
     TrackWithAds,
     TrailerInfo,
     User,
@@ -154,6 +166,8 @@ from . import (
     TestDiscreteScale,
     TestEnum,
     TestEvent,
+    TestFade,
+    TestForeignAgent,
     TestGeneratedPlaylist,
     TestIcon,
     TestId,
@@ -199,6 +213,7 @@ from . import (
     TestShotData,
     TestShotType,
     TestSimilarEntityItem,
+    TestSmartPreviewParams,
     TestStation,
     TestStationData,
     TestStationResult,
@@ -208,11 +223,14 @@ from . import (
     TestTag,
     TestTitle,
     TestTrack,
+    TestTrackCredit,
+    TestTrackFullInfo,
     TestTrackId,
     TestTrackLyrics,
     TestTrackPosition,
     TestTrackShort,
     TestTrackShortOld,
+    TestTrackTrailer,
     TestTrackWithAds,
     TestTrailerInfo,
     TestUser,
@@ -1487,6 +1505,13 @@ def pin_playlist(pin_data_playlist):
 
 
 @pytest.fixture(scope='session')
+def pins_list(pin_artist):
+    return PinsList(
+        pins=[pin_artist],
+    )
+
+
+@pytest.fixture(scope='session')
 def wave():
     return Wave(
         name=TestWave.name,
@@ -1523,6 +1548,13 @@ def similar_entity_item(similar_entity_data):
 
 
 @pytest.fixture(scope='session')
+def album_similar_entities(similar_entity_item):
+    return AlbumSimilarEntities(
+        items=[similar_entity_item],
+    )
+
+
+@pytest.fixture(scope='session')
 def trailer_info(track):
     return TrailerInfo(
         title=TestTrailerInfo.title,
@@ -1540,5 +1572,87 @@ def album_trailer(album, artist, trailer_info):
 
 
 @pytest.fixture(scope='session')
+def foreign_agent():
+    return ForeignAgent(
+        reason=TestForeignAgent.reason,
+        title=TestForeignAgent.title,
+    )
+
+
+@pytest.fixture(scope='session')
+def disclaimer(foreign_agent):
+    return Disclaimer(
+        foreign_agent=foreign_agent,
+    )
+
+
+@pytest.fixture(scope='session')
+def fade():
+    return Fade(
+        in_start=TestFade.in_start,
+        in_stop=TestFade.in_stop,
+        out_start=TestFade.out_start,
+        out_stop=TestFade.out_stop,
+    )
+
+
+@pytest.fixture(scope='session')
+def smart_preview_params(fade):
+    return SmartPreviewParams(
+        duration_ms=TestSmartPreviewParams.duration_ms,
+        fade=fade,
+    )
+
+
+@pytest.fixture(scope='session')
+def track_credit():
+    return TrackCredit(
+        title=TestTrackCredit.title,
+        value=TestTrackCredit.value,
+    )
+
+
+@pytest.fixture(scope='session')
+def track_credits(track_credit):
+    return TrackCredits(
+        credits=[track_credit],
+    )
+
+
+@pytest.fixture(scope='session')
+def track_trailer(track):
+    return TrackTrailer(
+        title=TestTrackTrailer.title,
+        track=track,
+    )
+
+
+@pytest.fixture(scope='session')
+def track_full_info(track, artist):
+    return TrackFullInfo(
+        track=track,
+        similar_tracks=[track],
+        also_in_albums=[track],
+        aliases=TestTrackFullInfo.aliases,
+        artists=[artist],
+    )
+
+
+@pytest.fixture(scope='session')
 def artist_link():
     return ArtistLink(TestArtistLink.title, TestArtistLink.subtitle, TestArtistLink.url, TestArtistLink.img_url)
+
+
+@pytest.fixture(scope='session')
+def artist_links_fixture(artist_link):
+    return ArtistLinks(
+        links=[artist_link],
+    )
+
+
+@pytest.fixture(scope='session')
+def artist_similar(artist):
+    return ArtistSimilar(
+        artist=artist,
+        similar_artists=[artist],
+    )

--- a/tests/test_album_similar_entities.py
+++ b/tests/test_album_similar_entities.py
@@ -1,0 +1,26 @@
+from yandex_music import AlbumSimilarEntities
+
+
+class TestAlbumSimilarEntities:
+    def test_expected_value(self, album_similar_entities, similar_entity_item):
+        assert album_similar_entities.items == [similar_entity_item]
+
+    def test_de_json_none(self, client):
+        assert AlbumSimilarEntities.de_json({}, client) is None
+
+    def test_de_json_all(self, client, similar_entity_item):
+        json_dict = {
+            'items': [similar_entity_item.to_dict()],
+        }
+        album_similar_entities = AlbumSimilarEntities.de_json(json_dict, client)
+
+        assert album_similar_entities.items == [similar_entity_item]
+
+    def test_equality(self, similar_entity_item):
+        a = AlbumSimilarEntities(items=[similar_entity_item])
+        b = AlbumSimilarEntities(items=None)
+        c = AlbumSimilarEntities(items=[similar_entity_item])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_artist_links.py
+++ b/tests/test_artist_links.py
@@ -1,0 +1,26 @@
+from yandex_music import ArtistLinks
+
+
+class TestArtistLinks:
+    def test_expected_value(self, artist_links_fixture, artist_link):
+        assert artist_links_fixture.links == [artist_link]
+
+    def test_de_json_none(self, client):
+        assert ArtistLinks.de_json({}, client) is None
+
+    def test_de_json_all(self, client, artist_link):
+        json_dict = {
+            'links': [artist_link.to_dict()],
+        }
+        artist_links = ArtistLinks.de_json(json_dict, client)
+
+        assert artist_links.links == [artist_link]
+
+    def test_equality(self, artist_link):
+        a = ArtistLinks(links=[artist_link])
+        b = ArtistLinks(links=None)
+        c = ArtistLinks(links=[artist_link])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_artist_similar.py
+++ b/tests/test_artist_similar.py
@@ -1,0 +1,29 @@
+from yandex_music import ArtistSimilar
+
+
+class TestArtistSimilar:
+    def test_expected_value(self, artist_similar, artist):
+        assert artist_similar.artist == artist
+        assert artist_similar.similar_artists == [artist]
+
+    def test_de_json_none(self, client):
+        assert ArtistSimilar.de_json({}, client) is None
+
+    def test_de_json_all(self, client, artist):
+        json_dict = {
+            'artist': artist.to_dict(),
+            'similarArtists': [artist.to_dict()],
+        }
+        artist_similar = ArtistSimilar.de_json(json_dict, client)
+
+        assert artist_similar.artist == artist
+        assert artist_similar.similar_artists == [artist]
+
+    def test_equality(self, artist):
+        a = ArtistSimilar(artist=artist)
+        b = ArtistSimilar(artist=None)
+        c = ArtistSimilar(artist=artist)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_disclaimer.py
+++ b/tests/test_disclaimer.py
@@ -1,0 +1,26 @@
+from yandex_music import Disclaimer
+
+
+class TestDisclaimer:
+    def test_expected_value(self, disclaimer, foreign_agent):
+        assert disclaimer.foreign_agent == foreign_agent
+
+    def test_de_json_none(self, client):
+        assert Disclaimer.de_json({}, client) is None
+
+    def test_de_json_all(self, client, foreign_agent):
+        json_dict = {
+            'foreignAgent': foreign_agent.to_dict(),
+        }
+        disclaimer = Disclaimer.de_json(json_dict, client)
+
+        assert disclaimer.foreign_agent == foreign_agent
+
+    def test_equality(self, foreign_agent):
+        a = Disclaimer(foreign_agent=foreign_agent)
+        b = Disclaimer(foreign_agent=None)
+        c = Disclaimer(foreign_agent=foreign_agent)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_fade.py
+++ b/tests/test_fade.py
@@ -1,0 +1,40 @@
+from yandex_music import Fade
+
+
+class TestFade:
+    in_start = 0.2
+    in_stop = 1.5
+    out_start = 191.9
+    out_stop = 196.9
+
+    def test_expected_values(self, fade):
+        assert fade.in_start == self.in_start
+        assert fade.in_stop == self.in_stop
+        assert fade.out_start == self.out_start
+        assert fade.out_stop == self.out_stop
+
+    def test_de_json_none(self, client):
+        assert Fade.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'inStart': self.in_start,
+            'inStop': self.in_stop,
+            'outStart': self.out_start,
+            'outStop': self.out_stop,
+        }
+        fade = Fade.de_json(json_dict, client)
+
+        assert fade.in_start == self.in_start
+        assert fade.in_stop == self.in_stop
+        assert fade.out_start == self.out_start
+        assert fade.out_stop == self.out_stop
+
+    def test_equality(self):
+        a = Fade(in_start=self.in_start, in_stop=self.in_stop, out_start=self.out_start, out_stop=self.out_stop)
+        b = Fade(in_start=0.0, in_stop=self.in_stop, out_start=self.out_start, out_stop=self.out_stop)
+        c = Fade(in_start=self.in_start, in_stop=self.in_stop, out_start=self.out_start, out_stop=self.out_stop)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_foreign_agent.py
+++ b/tests/test_foreign_agent.py
@@ -1,0 +1,32 @@
+from yandex_music import ForeignAgent
+
+
+class TestForeignAgent:
+    reason = 'policy'
+    title = 'ИСПОЛНИТЕЛЬ ПРИЗНАН ИНОАГЕНТОМ'
+
+    def test_expected_value(self, foreign_agent):
+        assert foreign_agent.reason == self.reason
+        assert foreign_agent.title == self.title
+
+    def test_de_json_none(self, client):
+        assert ForeignAgent.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'reason': self.reason,
+            'title': self.title,
+        }
+        foreign_agent = ForeignAgent.de_json(json_dict, client)
+
+        assert foreign_agent.reason == self.reason
+        assert foreign_agent.title == self.title
+
+    def test_equality(self):
+        a = ForeignAgent(reason=self.reason, title=self.title)
+        b = ForeignAgent(reason='other', title=self.title)
+        c = ForeignAgent(reason=self.reason, title=self.title)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_pins_list.py
+++ b/tests/test_pins_list.py
@@ -1,0 +1,26 @@
+from yandex_music import PinsList
+
+
+class TestPinsList:
+    def test_expected_value(self, pins_list, pin_artist):
+        assert pins_list.pins == [pin_artist]
+
+    def test_de_json_none(self, client):
+        assert PinsList.de_json({}, client) is None
+
+    def test_de_json_all(self, client, pin_artist):
+        json_dict = {
+            'pins': [pin_artist.to_dict()],
+        }
+        pins_list = PinsList.de_json(json_dict, client)
+
+        assert pins_list.pins == [pin_artist]
+
+    def test_equality(self, pin_artist):
+        a = PinsList(pins=[pin_artist])
+        b = PinsList(pins=None)
+        c = PinsList(pins=[pin_artist])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_smart_preview_params.py
+++ b/tests/test_smart_preview_params.py
@@ -1,0 +1,31 @@
+from yandex_music import SmartPreviewParams
+
+
+class TestSmartPreviewParams:
+    duration_ms = 17700
+
+    def test_expected_value(self, smart_preview_params, fade):
+        assert smart_preview_params.duration_ms == self.duration_ms
+        assert smart_preview_params.fade == fade
+
+    def test_de_json_none(self, client):
+        assert SmartPreviewParams.de_json({}, client) is None
+
+    def test_de_json_all(self, client, fade):
+        json_dict = {
+            'durationMs': self.duration_ms,
+            'fade': fade.to_dict(),
+        }
+        smart_preview_params = SmartPreviewParams.de_json(json_dict, client)
+
+        assert smart_preview_params.duration_ms == self.duration_ms
+        assert smart_preview_params.fade == fade
+
+    def test_equality(self, fade):
+        a = SmartPreviewParams(duration_ms=self.duration_ms, fade=fade)
+        b = SmartPreviewParams(duration_ms=10000, fade=fade)
+        c = SmartPreviewParams(duration_ms=self.duration_ms, fade=fade)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_track_credit.py
+++ b/tests/test_track_credit.py
@@ -1,0 +1,32 @@
+from yandex_music import TrackCredit
+
+
+class TestTrackCredit:
+    title = 'Автор музыки'
+    value = 'Тестовый Исполнитель'
+
+    def test_expected_value(self, track_credit):
+        assert track_credit.title == self.title
+        assert track_credit.value == self.value
+
+    def test_de_json_none(self, client):
+        assert TrackCredit.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'title': self.title,
+            'value': self.value,
+        }
+        track_credit = TrackCredit.de_json(json_dict, client)
+
+        assert track_credit.title == self.title
+        assert track_credit.value == self.value
+
+    def test_equality(self):
+        a = TrackCredit(title=self.title, value=self.value)
+        b = TrackCredit(title='Лейбл', value=self.value)
+        c = TrackCredit(title=self.title, value=self.value)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_track_credits.py
+++ b/tests/test_track_credits.py
@@ -1,0 +1,26 @@
+from yandex_music import TrackCredits
+
+
+class TestTrackCredits:
+    def test_expected_value(self, track_credits, track_credit):
+        assert track_credits.credits == [track_credit]
+
+    def test_de_json_none(self, client):
+        assert TrackCredits.de_json({}, client) is None
+
+    def test_de_json_all(self, client, track_credit):
+        json_dict = {
+            'credits': [track_credit.to_dict()],
+        }
+        track_credits = TrackCredits.de_json(json_dict, client)
+
+        assert track_credits.credits == [track_credit]
+
+    def test_equality(self, track_credit):
+        a = TrackCredits(credits=[track_credit])
+        b = TrackCredits(credits=None)
+        c = TrackCredits(credits=[track_credit])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_track_full_info.py
+++ b/tests/test_track_full_info.py
@@ -1,0 +1,40 @@
+from yandex_music import TrackFullInfo
+
+
+class TestTrackFullInfo:
+    aliases = ['alias1', 'alias2']
+
+    def test_expected_value(self, track_full_info, track, artist):
+        assert track_full_info.track == track
+        assert track_full_info.similar_tracks == [track]
+        assert track_full_info.also_in_albums == [track]
+        assert track_full_info.aliases == self.aliases
+        assert track_full_info.artists == [artist]
+
+    def test_de_json_none(self, client):
+        assert TrackFullInfo.de_json({}, client) is None
+
+    def test_de_json_all(self, client, track, artist):
+        json_dict = {
+            'track': track.to_dict(),
+            'similarTracks': [track.to_dict()],
+            'alsoInAlbums': [track.to_dict()],
+            'aliases': self.aliases,
+            'artists': [artist.to_dict()],
+        }
+        track_full_info = TrackFullInfo.de_json(json_dict, client)
+
+        assert track_full_info.track == track
+        assert track_full_info.similar_tracks == [track]
+        assert track_full_info.also_in_albums == [track]
+        assert track_full_info.aliases == self.aliases
+        assert track_full_info.artists == [artist]
+
+    def test_equality(self, track):
+        a = TrackFullInfo(track=track)
+        b = TrackFullInfo(track=None)
+        c = TrackFullInfo(track=track)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_track_trailer.py
+++ b/tests/test_track_trailer.py
@@ -1,0 +1,31 @@
+from yandex_music import TrackTrailer
+
+
+class TestTrackTrailer:
+    title = 'Трейлер трека'
+
+    def test_expected_value(self, track_trailer, track):
+        assert track_trailer.title == self.title
+        assert track_trailer.track == track
+
+    def test_de_json_none(self, client):
+        assert TrackTrailer.de_json({}, client) is None
+
+    def test_de_json_all(self, client, track):
+        json_dict = {
+            'title': self.title,
+            'track': track.to_dict(),
+        }
+        track_trailer = TrackTrailer.de_json(json_dict, client)
+
+        assert track_trailer.title == self.title
+        assert track_trailer.track == track
+
+    def test_equality(self, track):
+        a = TrackTrailer(title=self.title, track=track)
+        b = TrackTrailer(title=None, track=track)
+        c = TrackTrailer(title=self.title, track=track)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/yandex_music/__init__.py
+++ b/yandex_music/__init__.py
@@ -26,6 +26,7 @@ from .account.passport_phone import PassportPhone
 from .account.permissions import Permissions
 
 from .album.album import Album
+from .album.album_similar_entities import AlbumSimilarEntities
 from .album.album_trailer import AlbumTrailer
 from .album.label import Label
 from .album.track_position import TrackPosition
@@ -35,6 +36,8 @@ from .album.deprecation import Deprecation
 from .artist.artist import Artist
 from .artist.artist_albums import ArtistAlbums
 from .artist.artist_link import ArtistLink
+from .artist.artist_links import ArtistLinks
+from .artist.artist_similar import ArtistSimilar
 from .artist.artist_tracks import ArtistTracks
 from .artist.brief_info import BriefInfo
 from .artist.counts import Counts
@@ -82,6 +85,12 @@ from .track.track import Track
 from .track.tracks_similar import SimilarTracks
 from .track.r128 import R128
 from .track.lyrics_info import LyricsInfo
+from .track.fade import Fade
+from .track.smart_preview_params import SmartPreviewParams
+from .track.track_credit import TrackCredit
+from .track.track_credits import TrackCredits
+from .track.track_trailer import TrackTrailer
+from .track.track_full_info import TrackFullInfo
 
 from .feed.generated_playlist import GeneratedPlaylist
 from .feed.album_event import AlbumEvent
@@ -150,6 +159,8 @@ from .wave.similar_entity_data import SimilarEntityData
 from .wave.similar_entity_item import SimilarEntityItem
 
 from .content_restrictions import ContentRestrictions
+from .disclaimer import Disclaimer
+from .foreign_agent import ForeignAgent
 from .like import Like
 from .pager import Pager
 from .cover import Cover
@@ -159,6 +170,7 @@ from .track_short import TrackShort
 from .icon import Icon
 from .pin.pin_data import PinData
 from .pin.pin import Pin
+from .pin.pins_list import PinsList
 from .client import Client
 from .client_async import ClientAsync
 
@@ -169,6 +181,7 @@ __all__ = [
     'AdParams',
     'Album',
     'AlbumEvent',
+    'AlbumSimilarEntities',
     'AlbumTrailer',
     'Alert',
     'AlertButton',
@@ -177,6 +190,8 @@ __all__ = [
     'ArtistConcerts',
     'ArtistEvent',
     'ArtistLink',
+    'ArtistLinks',
+    'ArtistSimilar',
     'ArtistTracks',
     'AutoRenewable',
     'Best',
@@ -209,12 +224,15 @@ __all__ = [
     'Deactivation',
     'Deprecation',
     'Description',
+    'Disclaimer',
     'DiscreteScale',
     'DownloadInfo',
     'Enum',
     'Event',
     'Experiments',
+    'Fade',
     'Feed',
+    'ForeignAgent',
     'GeneratedPlaylist',
     'Genre',
     'Icon',
@@ -247,6 +265,7 @@ __all__ = [
     'PersonalPlaylistsData',
     'Pin',
     'PinData',
+    'PinsList',
     'PlayContext',
     'PlayContextsData',
     'PlayCounter',
@@ -277,6 +296,7 @@ __all__ = [
     'SimilarEntityData',
     'SimilarEntityItem',
     'SimilarTracks',
+    'SmartPreviewParams',
     'Station',
     'StationData',
     'StationResult',
@@ -290,11 +310,15 @@ __all__ = [
     'TagResult',
     'Title',
     'Track',
+    'TrackCredit',
+    'TrackCredits',
+    'TrackFullInfo',
     'TrackId',
     'TrackLyrics',
     'TrackPosition',
     'TrackShort',
     'TrackShortOld',
+    'TrackTrailer',
     'TrackWithAds',
     'TracksList',
     'TrailerInfo',

--- a/yandex_music/_client/albums.py
+++ b/yandex_music/_client/albums.py
@@ -2,11 +2,11 @@
 # THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/albums.py. DON'T EDIT IT BY HANDS #
 ###############################################################################################
 
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-from yandex_music import Album, AlbumTrailer, SimilarEntityItem
+from yandex_music import Album, AlbumSimilarEntities, AlbumTrailer, Disclaimer
 from yandex_music._client import log
-from yandex_music._client_base import ClientBase, is_dict
+from yandex_music._client_base import ClientBase
 
 if TYPE_CHECKING:
     from yandex_music.utils.request import Request
@@ -39,7 +39,7 @@ class AlbumsMixin(ClientBase):
         return Album.de_json(result, self)
 
     @log
-    def albums_disclaimer(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[str]:
+    def albums_disclaimer(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[Disclaimer]:
         """Получение дисклеймера альбома.
 
         Args:
@@ -48,7 +48,7 @@ class AlbumsMixin(ClientBase):
             **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
 
         Returns:
-            :obj:`str` | :obj:`None`: Текст дисклеймера или :obj:`None`.
+            :obj:`yandex_music.Disclaimer` | :obj:`None`: Дисклеймер альбома или :obj:`None`.
 
         Raises:
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
@@ -57,12 +57,12 @@ class AlbumsMixin(ClientBase):
 
         result = self._request.get(url, *args, **kwargs)
 
-        if is_dict(result):
-            return result.get('text')
-        return None
+        return Disclaimer.de_json(result, self)
 
     @log
-    def albums_similar_entities(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> List[SimilarEntityItem]:
+    def albums_similar_entities(
+        self, album_id: Union[str, int], *args: Any, **kwargs: Any
+    ) -> Optional[AlbumSimilarEntities]:
         """Получение похожих сущностей для альбома.
 
         Args:
@@ -71,7 +71,7 @@ class AlbumsMixin(ClientBase):
             **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
 
         Returns:
-            :obj:`list` из :obj:`yandex_music.SimilarEntityItem`: Список похожих сущностей.
+            :obj:`yandex_music.AlbumSimilarEntities` | :obj:`None`: Похожие сущности или :obj:`None`.
 
         Raises:
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
@@ -80,9 +80,7 @@ class AlbumsMixin(ClientBase):
 
         result = self._request.get(url, *args, **kwargs)
 
-        if is_dict(result):
-            return list(SimilarEntityItem.de_list(result.get('items'), self))
-        return []
+        return AlbumSimilarEntities.de_json(result, self)
 
     @log
     def albums_trailer(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[AlbumTrailer]:

--- a/yandex_music/_client/artists.py
+++ b/yandex_music/_client/artists.py
@@ -4,9 +4,9 @@
 
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from yandex_music import Artist, ArtistAlbums, ArtistConcerts, ArtistLink, ArtistTracks, BriefInfo
+from yandex_music import ArtistAlbums, ArtistConcerts, ArtistLinks, ArtistSimilar, ArtistTracks, BriefInfo
 from yandex_music._client import log
-from yandex_music._client_base import ClientBase, is_dict
+from yandex_music._client_base import ClientBase
 
 if TYPE_CHECKING:
     from yandex_music.utils.request import Request
@@ -113,7 +113,7 @@ class ArtistsMixin(ClientBase):
         artist_id: Union[str, int],
         *args: Any,
         **kwargs: Any,
-    ) -> List[Artist]:
+    ) -> Optional[ArtistSimilar]:
         """Получение похожих артистов.
 
         Args:
@@ -122,7 +122,7 @@ class ArtistsMixin(ClientBase):
             **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
 
         Returns:
-            :obj:`list` из :obj:`yandex_music.Artist`: Список похожих артистов.
+            :obj:`yandex_music.ArtistSimilar` | :obj:`None`: Похожие артисты или :obj:`None`.
 
         Raises:
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
@@ -131,10 +131,7 @@ class ArtistsMixin(ClientBase):
 
         result = self._request.get(url, *args, **kwargs)
 
-        if is_dict(result):
-            return list(Artist.de_list(result.get('similar_artists', []), self))
-
-        return []
+        return ArtistSimilar.de_json(result, self)
 
     @log
     def artists_links(
@@ -142,7 +139,7 @@ class ArtistsMixin(ClientBase):
         artist_id: Union[str, int],
         *args: Any,
         **kwargs: Any,
-    ) -> List[ArtistLink]:
+    ) -> Optional[ArtistLinks]:
         """Получение ссылок на страницы артиста.
 
         Args:
@@ -151,7 +148,7 @@ class ArtistsMixin(ClientBase):
             **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
 
         Returns:
-            :obj:`list` из :obj:`yandex_music.ArtistLink`: Список ссылок на страницы артиста.
+            :obj:`yandex_music.ArtistLinks` | :obj:`None`: Ссылки на страницы артиста или :obj:`None`.
 
         Raises:
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
@@ -160,10 +157,7 @@ class ArtistsMixin(ClientBase):
 
         result = self._request.get(url, *args, **kwargs)
 
-        if is_dict(result):
-            return list(ArtistLink.de_list(result.get('links', []), self))
-
-        return []
+        return ArtistLinks.de_json(result, self)
 
     @log
     def artists_also_albums(

--- a/yandex_music/_client/pins.py
+++ b/yandex_music/_client/pins.py
@@ -2,9 +2,9 @@
 # THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/pins.py. DON'T EDIT IT BY HANDS #
 #############################################################################################
 
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-from yandex_music import Pin
+from yandex_music import Pin, PinsList
 from yandex_music._client import log
 from yandex_music._client_base import ClientBase
 
@@ -18,7 +18,7 @@ class PinsMixin(ClientBase):
     _request: 'Request'
 
     @log
-    def pins(self, *args: Any, **kwargs: Any) -> List[Pin]:
+    def pins(self, *args: Any, **kwargs: Any) -> Optional[PinsList]:
         """Получение списка закреплённых элементов.
 
         Args:
@@ -26,7 +26,7 @@ class PinsMixin(ClientBase):
             **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
 
         Returns:
-            :obj:`list` из :obj:`yandex_music.Pin`: Список закреплённых элементов.
+            :obj:`yandex_music.PinsList` | :obj:`None`: Список закреплённых элементов или :obj:`None`.
 
         Raises:
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
@@ -35,10 +35,7 @@ class PinsMixin(ClientBase):
 
         result = self._request.get(url, *args, **kwargs)
 
-        if isinstance(result, dict):
-            return list(Pin.de_list(result.get('pins'), self))
-
-        return []
+        return PinsList.de_json(result, self)
 
     @log
     def pin_album(self, album_id: Union[str, int], **kwargs: Any) -> Optional[Pin]:

--- a/yandex_music/_client/tracks.py
+++ b/yandex_music/_client/tracks.py
@@ -5,7 +5,17 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from yandex_music import DownloadInfo, ShotEvent, SimilarTracks, Supplement, TrackLyrics
+from yandex_music import (
+    Disclaimer,
+    DownloadInfo,
+    ShotEvent,
+    SimilarTracks,
+    Supplement,
+    TrackCredits,
+    TrackFullInfo,
+    TrackLyrics,
+    TrackTrailer,
+)
 from yandex_music._client import log
 from yandex_music._client_base import ClientBase, is_dict
 from yandex_music.utils.sign_request import get_sign_request
@@ -262,6 +272,90 @@ class TracksMixin(ClientBase):
             return ShotEvent.de_json(result.get('shotEvent'), self)
         return None
 
+    @log
+    def tracks_credits(self, track_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[TrackCredits]:
+        """Получение информации об участниках создания трека.
+
+        Args:
+            track_id (:obj:`str` | :obj:`int`): Уникальный идентификатор трека.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.TrackCredits` | :obj:`None`: Участники создания трека или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/tracks/{track_id}/credits'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return TrackCredits.de_json(result, self)
+
+    @log
+    def tracks_disclaimer(self, track_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[Disclaimer]:
+        """Получение дисклеймера трека.
+
+        Args:
+            track_id (:obj:`str` | :obj:`int`): Уникальный идентификатор трека.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Disclaimer` | :obj:`None`: Дисклеймер трека или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/tracks/{track_id}/disclaimer'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return Disclaimer.de_json(result, self)
+
+    @log
+    def tracks_trailer(self, track_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[TrackTrailer]:
+        """Получение трейлера трека.
+
+        Args:
+            track_id (:obj:`str` | :obj:`int`): Уникальный идентификатор трека.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.TrackTrailer` | :obj:`None`: Трейлер трека или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/tracks/{track_id}/trailer'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return TrackTrailer.de_json(result, self)
+
+    @log
+    def tracks_full_info(self, track_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[TrackFullInfo]:
+        """Получение полной информации о треке.
+
+        Args:
+            track_id (:obj:`str` | :obj:`int`): Уникальный идентификатор трека.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.TrackFullInfo` | :obj:`None`: Полная информация о треке или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/tracks/{track_id}/full-info'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return TrackFullInfo.de_json(result, self)
+
     # camelCase псевдонимы
 
     #: Псевдоним для :attr:`tracks_download_info`
@@ -276,3 +370,11 @@ class TracksMixin(ClientBase):
     playAudio = play_audio
     #: Псевдоним для :attr:`after_track`
     afterTrack = after_track
+    #: Псевдоним для :attr:`tracks_credits`
+    tracksCredits = tracks_credits
+    #: Псевдоним для :attr:`tracks_disclaimer`
+    tracksDisclaimer = tracks_disclaimer
+    #: Псевдоним для :attr:`tracks_trailer`
+    tracksTrailer = tracks_trailer
+    #: Псевдоним для :attr:`tracks_full_info`
+    tracksFullInfo = tracks_full_info

--- a/yandex_music/_client_async/albums.py
+++ b/yandex_music/_client_async/albums.py
@@ -1,8 +1,8 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-from yandex_music import Album, AlbumTrailer, SimilarEntityItem
+from yandex_music import Album, AlbumSimilarEntities, AlbumTrailer, Disclaimer
 from yandex_music._client_async import log
-from yandex_music._client_base import ClientBase, is_dict
+from yandex_music._client_base import ClientBase
 
 if TYPE_CHECKING:
     from yandex_music.utils.request_async import Request
@@ -35,7 +35,7 @@ class AlbumsMixin(ClientBase):
         return Album.de_json(result, self)
 
     @log
-    async def albums_disclaimer(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[str]:
+    async def albums_disclaimer(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[Disclaimer]:
         """Получение дисклеймера альбома.
 
         Args:
@@ -44,7 +44,7 @@ class AlbumsMixin(ClientBase):
             **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
 
         Returns:
-            :obj:`str` | :obj:`None`: Текст дисклеймера или :obj:`None`.
+            :obj:`yandex_music.Disclaimer` | :obj:`None`: Дисклеймер альбома или :obj:`None`.
 
         Raises:
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
@@ -53,14 +53,12 @@ class AlbumsMixin(ClientBase):
 
         result = await self._request.get(url, *args, **kwargs)
 
-        if is_dict(result):
-            return result.get('text')
-        return None
+        return Disclaimer.de_json(result, self)
 
     @log
     async def albums_similar_entities(
         self, album_id: Union[str, int], *args: Any, **kwargs: Any
-    ) -> List[SimilarEntityItem]:
+    ) -> Optional[AlbumSimilarEntities]:
         """Получение похожих сущностей для альбома.
 
         Args:
@@ -69,7 +67,7 @@ class AlbumsMixin(ClientBase):
             **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
 
         Returns:
-            :obj:`list` из :obj:`yandex_music.SimilarEntityItem`: Список похожих сущностей.
+            :obj:`yandex_music.AlbumSimilarEntities` | :obj:`None`: Похожие сущности или :obj:`None`.
 
         Raises:
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
@@ -78,9 +76,7 @@ class AlbumsMixin(ClientBase):
 
         result = await self._request.get(url, *args, **kwargs)
 
-        if is_dict(result):
-            return list(SimilarEntityItem.de_list(result.get('items'), self))
-        return []
+        return AlbumSimilarEntities.de_json(result, self)
 
     @log
     async def albums_trailer(self, album_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[AlbumTrailer]:

--- a/yandex_music/_client_async/artists.py
+++ b/yandex_music/_client_async/artists.py
@@ -1,8 +1,8 @@
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from yandex_music import Artist, ArtistAlbums, ArtistConcerts, ArtistLink, ArtistTracks, BriefInfo
+from yandex_music import ArtistAlbums, ArtistConcerts, ArtistLinks, ArtistSimilar, ArtistTracks, BriefInfo
 from yandex_music._client_async import log
-from yandex_music._client_base import ClientBase, is_dict
+from yandex_music._client_base import ClientBase
 
 if TYPE_CHECKING:
     from yandex_music.utils.request_async import Request
@@ -109,7 +109,7 @@ class ArtistsMixin(ClientBase):
         artist_id: Union[str, int],
         *args: Any,
         **kwargs: Any,
-    ) -> List[Artist]:
+    ) -> Optional[ArtistSimilar]:
         """Получение похожих артистов.
 
         Args:
@@ -118,7 +118,7 @@ class ArtistsMixin(ClientBase):
             **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
 
         Returns:
-            :obj:`list` из :obj:`yandex_music.Artist`: Список похожих артистов.
+            :obj:`yandex_music.ArtistSimilar` | :obj:`None`: Похожие артисты или :obj:`None`.
 
         Raises:
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
@@ -127,10 +127,7 @@ class ArtistsMixin(ClientBase):
 
         result = await self._request.get(url, *args, **kwargs)
 
-        if is_dict(result):
-            return list(Artist.de_list(result.get('similar_artists', []), self))
-
-        return []
+        return ArtistSimilar.de_json(result, self)
 
     @log
     async def artists_links(
@@ -138,7 +135,7 @@ class ArtistsMixin(ClientBase):
         artist_id: Union[str, int],
         *args: Any,
         **kwargs: Any,
-    ) -> List[ArtistLink]:
+    ) -> Optional[ArtistLinks]:
         """Получение ссылок на страницы артиста.
 
         Args:
@@ -147,7 +144,7 @@ class ArtistsMixin(ClientBase):
             **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
 
         Returns:
-            :obj:`list` из :obj:`yandex_music.ArtistLink`: Список ссылок на страницы артиста.
+            :obj:`yandex_music.ArtistLinks` | :obj:`None`: Ссылки на страницы артиста или :obj:`None`.
 
         Raises:
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
@@ -156,10 +153,7 @@ class ArtistsMixin(ClientBase):
 
         result = await self._request.get(url, *args, **kwargs)
 
-        if is_dict(result):
-            return list(ArtistLink.de_list(result.get('links', []), self))
-
-        return []
+        return ArtistLinks.de_json(result, self)
 
     @log
     async def artists_also_albums(

--- a/yandex_music/_client_async/pins.py
+++ b/yandex_music/_client_async/pins.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-from yandex_music import Pin
+from yandex_music import Pin, PinsList
 from yandex_music._client_async import log
 from yandex_music._client_base import ClientBase
 
@@ -14,7 +14,7 @@ class PinsMixin(ClientBase):
     _request: 'Request'
 
     @log
-    async def pins(self, *args: Any, **kwargs: Any) -> List[Pin]:
+    async def pins(self, *args: Any, **kwargs: Any) -> Optional[PinsList]:
         """Получение списка закреплённых элементов.
 
         Args:
@@ -22,7 +22,7 @@ class PinsMixin(ClientBase):
             **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
 
         Returns:
-            :obj:`list` из :obj:`yandex_music.Pin`: Список закреплённых элементов.
+            :obj:`yandex_music.PinsList` | :obj:`None`: Список закреплённых элементов или :obj:`None`.
 
         Raises:
             :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
@@ -31,10 +31,7 @@ class PinsMixin(ClientBase):
 
         result = await self._request.get(url, *args, **kwargs)
 
-        if isinstance(result, dict):
-            return list(Pin.de_list(result.get('pins'), self))
-
-        return []
+        return PinsList.de_json(result, self)
 
     @log
     async def pin_album(self, album_id: Union[str, int], **kwargs: Any) -> Optional[Pin]:

--- a/yandex_music/_client_async/tracks.py
+++ b/yandex_music/_client_async/tracks.py
@@ -1,7 +1,17 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from yandex_music import DownloadInfo, ShotEvent, SimilarTracks, Supplement, TrackLyrics
+from yandex_music import (
+    Disclaimer,
+    DownloadInfo,
+    ShotEvent,
+    SimilarTracks,
+    Supplement,
+    TrackCredits,
+    TrackFullInfo,
+    TrackLyrics,
+    TrackTrailer,
+)
 from yandex_music._client_async import log
 from yandex_music._client_base import ClientBase, is_dict
 from yandex_music.utils.sign_request import get_sign_request
@@ -258,6 +268,90 @@ class TracksMixin(ClientBase):
             return ShotEvent.de_json(result.get('shotEvent'), self)
         return None
 
+    @log
+    async def tracks_credits(self, track_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[TrackCredits]:
+        """Получение информации об участниках создания трека.
+
+        Args:
+            track_id (:obj:`str` | :obj:`int`): Уникальный идентификатор трека.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.TrackCredits` | :obj:`None`: Участники создания трека или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/tracks/{track_id}/credits'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return TrackCredits.de_json(result, self)
+
+    @log
+    async def tracks_disclaimer(self, track_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[Disclaimer]:
+        """Получение дисклеймера трека.
+
+        Args:
+            track_id (:obj:`str` | :obj:`int`): Уникальный идентификатор трека.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Disclaimer` | :obj:`None`: Дисклеймер трека или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/tracks/{track_id}/disclaimer'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return Disclaimer.de_json(result, self)
+
+    @log
+    async def tracks_trailer(self, track_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[TrackTrailer]:
+        """Получение трейлера трека.
+
+        Args:
+            track_id (:obj:`str` | :obj:`int`): Уникальный идентификатор трека.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.TrackTrailer` | :obj:`None`: Трейлер трека или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/tracks/{track_id}/trailer'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return TrackTrailer.de_json(result, self)
+
+    @log
+    async def tracks_full_info(self, track_id: Union[str, int], *args: Any, **kwargs: Any) -> Optional[TrackFullInfo]:
+        """Получение полной информации о треке.
+
+        Args:
+            track_id (:obj:`str` | :obj:`int`): Уникальный идентификатор трека.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.TrackFullInfo` | :obj:`None`: Полная информация о треке или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/tracks/{track_id}/full-info'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return TrackFullInfo.de_json(result, self)
+
     # camelCase псевдонимы
 
     #: Псевдоним для :attr:`tracks_download_info`
@@ -272,3 +366,11 @@ class TracksMixin(ClientBase):
     playAudio = play_audio
     #: Псевдоним для :attr:`after_track`
     afterTrack = after_track
+    #: Псевдоним для :attr:`tracks_credits`
+    tracksCredits = tracks_credits
+    #: Псевдоним для :attr:`tracks_disclaimer`
+    tracksDisclaimer = tracks_disclaimer
+    #: Псевдоним для :attr:`tracks_trailer`
+    tracksTrailer = tracks_trailer
+    #: Псевдоним для :attr:`tracks_full_info`
+    tracksFullInfo = tracks_full_info

--- a/yandex_music/album/album_similar_entities.py
+++ b/yandex_music/album/album_similar_entities.py
@@ -1,0 +1,44 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType, SimilarEntityItem
+
+
+@model
+class AlbumSimilarEntities(YandexMusicModel):
+    """Класс, представляющий похожие сущности для альбома.
+
+    Attributes:
+        items (:obj:`list` из :obj:`yandex_music.SimilarEntityItem`, optional): Список похожих сущностей.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    items: Optional[List['SimilarEntityItem']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.items,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['AlbumSimilarEntities']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.AlbumSimilarEntities`: Похожие сущности для альбома.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import SimilarEntityItem
+
+        cls_data['items'] = SimilarEntityItem.de_list(cls_data.get('items'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/artist/artist_links.py
+++ b/yandex_music/artist/artist_links.py
@@ -1,0 +1,45 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.artist.artist_link import ArtistLink
+
+
+@model
+class ArtistLinks(YandexMusicModel):
+    """Класс, представляющий ссылки на страницы артиста.
+
+    Attributes:
+        links (:obj:`list` из :obj:`yandex_music.ArtistLink`, optional): Список ссылок.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    links: Optional[List['ArtistLink']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.links,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['ArtistLinks']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.ArtistLinks`: Ссылки на страницы артиста.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import ArtistLink
+
+        cls_data['links'] = ArtistLink.de_list(cls_data.get('links'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/artist/artist_similar.py
+++ b/yandex_music/artist/artist_similar.py
@@ -1,0 +1,48 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.artist.artist import Artist
+
+
+@model
+class ArtistSimilar(YandexMusicModel):
+    """Класс, представляющий похожих артистов.
+
+    Attributes:
+        artist (:obj:`yandex_music.Artist`, optional): Артист, для которого найдены похожие.
+        similar_artists (:obj:`list` из :obj:`yandex_music.Artist`, optional): Список похожих артистов.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    artist: Optional['Artist'] = None
+    similar_artists: Optional[List['Artist']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.artist, self.similar_artists)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['ArtistSimilar']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.ArtistSimilar`: Похожие артисты.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Artist
+
+        cls_data['artist'] = Artist.de_json(cls_data.get('artist'), client)
+        cls_data['similar_artists'] = Artist.de_list(cls_data.get('similar_artists'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/disclaimer.py
+++ b/yandex_music/disclaimer.py
@@ -1,0 +1,45 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.foreign_agent import ForeignAgent
+
+
+@model
+class Disclaimer(YandexMusicModel):
+    """Класс, представляющий дисклеймер.
+
+    Attributes:
+        foreign_agent (:obj:`yandex_music.ForeignAgent`, optional): Информация о статусе иноагента.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    foreign_agent: Optional['ForeignAgent'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.foreign_agent,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['Disclaimer']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.Disclaimer`: Дисклеймер.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.foreign_agent import ForeignAgent
+
+        cls_data['foreign_agent'] = ForeignAgent.de_json(cls_data.get('foreign_agent'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/foreign_agent.py
+++ b/yandex_music/foreign_agent.py
@@ -1,0 +1,28 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class ForeignAgent(YandexMusicModel):
+    """Класс, представляющий информацию о статусе иноагента.
+
+    Note:
+        Известные значения поля `reason`: `policy`.
+
+    Attributes:
+        reason (:obj:`str`, optional): Причина присвоения статуса.
+        title (:obj:`str`, optional): Текст предупреждения.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    reason: Optional[str] = None
+    title: Optional[str] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.reason, self.title)

--- a/yandex_music/pin/pins_list.py
+++ b/yandex_music/pin/pins_list.py
@@ -1,0 +1,45 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.pin.pin import Pin
+
+
+@model
+class PinsList(YandexMusicModel):
+    """Класс, представляющий список закреплённых элементов.
+
+    Attributes:
+        pins (:obj:`list` из :obj:`yandex_music.Pin`, optional): Список закреплённых элементов.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    pins: Optional[List['Pin']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.pins,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['PinsList']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.PinsList`: Список закреплённых элементов.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Pin
+
+        cls_data['pins'] = Pin.de_list(cls_data.get('pins'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/track/fade.py
+++ b/yandex_music/track/fade.py
@@ -1,0 +1,29 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class Fade(YandexMusicModel):
+    """Класс, представляющий параметры затухания трека.
+
+    Attributes:
+        in_start (:obj:`float`, optional): Начало нарастания звука в секундах.
+        in_stop (:obj:`float`, optional): Конец нарастания звука в секундах.
+        out_start (:obj:`float`, optional): Начало затухания звука в секундах.
+        out_stop (:obj:`float`, optional): Конец затухания звука в секундах.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    in_start: Optional[float] = None
+    in_stop: Optional[float] = None
+    out_start: Optional[float] = None
+    out_stop: Optional[float] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.in_start, self.in_stop, self.out_start, self.out_stop)

--- a/yandex_music/track/smart_preview_params.py
+++ b/yandex_music/track/smart_preview_params.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.track.fade import Fade
+
+
+@model
+class SmartPreviewParams(YandexMusicModel):
+    """Класс, представляющий параметры умного превью трека.
+
+    Attributes:
+        duration_ms (:obj:`int`, optional): Длительность превью в миллисекундах.
+        fade (:obj:`yandex_music.Fade`, optional): Параметры затухания превью.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    duration_ms: Optional[int] = None
+    fade: Optional['Fade'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.duration_ms, self.fade)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['SmartPreviewParams']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.SmartPreviewParams`: Параметры умного превью трека.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.track.fade import Fade
+
+        cls_data['fade'] = Fade.de_json(cls_data.get('fade'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/track/track.py
+++ b/yandex_music/track/track.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
         Album,
         Artist,
         ClientType,
+        CoverDerivedColors,
         DownloadInfo,
         JSONType,
         LyricsInfo,
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
         TrackLyrics,
         User,
     )
+    from yandex_music.track.fade import Fade
+    from yandex_music.track.smart_preview_params import SmartPreviewParams
 
 
 @model
@@ -92,6 +95,11 @@ class Track(YandexMusicModel):
             в соответствии с рекомендацией EBU R 128.
         lyrics_info (:obj:`yandex_music.LyricsInfo`, optional): Данные о наличии текстов трека.
         track_sharing_flag (:obj:`str`, optional): TODO.
+        derived_colors (:obj:`yandex_music.CoverDerivedColors`, optional): Производные цвета обложки трека.
+        fade (:obj:`yandex_music.Fade`, optional): Параметры затухания трека.
+        smart_preview_params (:obj:`yandex_music.SmartPreviewParams`, optional): Параметры умного превью трека.
+        special_audio_resources (:obj:`list` из :obj:`str`, optional): Специальные аудиоресурсы.
+        disclaimers (:obj:`list` из :obj:`str`, optional): Список дисклеймеров.
         client (:obj:`yandex_music.Client`): Клиент Yandex Music.
     """
 
@@ -138,6 +146,11 @@ class Track(YandexMusicModel):
     r128: Optional['R128'] = None
     lyrics_info: Optional['LyricsInfo'] = None
     track_sharing_flag: Optional[str] = None
+    derived_colors: Optional['CoverDerivedColors'] = None
+    fade: Optional['Fade'] = None
+    smart_preview_params: Optional['SmartPreviewParams'] = None
+    special_audio_resources: Optional[List[str]] = None
+    disclaimers: Optional[List[str]] = None
     client: Optional['ClientType'] = None
 
     def __post_init__(self) -> None:
@@ -504,7 +517,20 @@ class Track(YandexMusicModel):
             return None
 
         cls_data = cls.cleanup_data(data, client)
-        from yandex_music import R128, Album, Artist, LyricsInfo, Major, MetaData, Normalization, PoetryLoverMatch, User
+        from yandex_music import (
+            R128,
+            Album,
+            Artist,
+            CoverDerivedColors,
+            LyricsInfo,
+            Major,
+            MetaData,
+            Normalization,
+            PoetryLoverMatch,
+            User,
+        )
+        from yandex_music.track.fade import Fade
+        from yandex_music.track.smart_preview_params import SmartPreviewParams
 
         cls_data['albums'] = Album.de_list(cls_data.get('albums'), client)
         cls_data['artists'] = Artist.de_list(cls_data.get('artists'), client)
@@ -517,6 +543,9 @@ class Track(YandexMusicModel):
         cls_data['poetry_lover_matches'] = PoetryLoverMatch.de_list(cls_data.get('poetry_lover_matches'), client)
         cls_data['r128'] = R128.de_json(cls_data.get('r128'), client)
         cls_data['lyrics_info'] = LyricsInfo.de_json(cls_data.get('lyrics_info'), client)
+        cls_data['derived_colors'] = CoverDerivedColors.de_json(cls_data.get('derived_colors'), client)
+        cls_data['fade'] = Fade.de_json(cls_data.get('fade'), client)
+        cls_data['smart_preview_params'] = SmartPreviewParams.de_json(cls_data.get('smart_preview_params'), client)
 
         return cls(client=client, **cls_data)  # type: ignore
 

--- a/yandex_music/track/track_credit.py
+++ b/yandex_music/track/track_credit.py
@@ -1,0 +1,25 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class TrackCredit(YandexMusicModel):
+    """Класс, представляющий информацию об участнике создания трека.
+
+    Attributes:
+        title (:obj:`str`, optional): Роль участника (например, «Автор музыки», «Лейбл»).
+        value (:obj:`str`, optional): Имя или название участника.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    title: Optional[str] = None
+    value: Optional[str] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.title, self.value)

--- a/yandex_music/track/track_credits.py
+++ b/yandex_music/track/track_credits.py
@@ -1,0 +1,45 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.track.track_credit import TrackCredit
+
+
+@model
+class TrackCredits(YandexMusicModel):
+    """Класс, представляющий список участников создания трека.
+
+    Attributes:
+        credits (:obj:`list` из :obj:`yandex_music.TrackCredit`, optional): Список участников.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    credits: Optional[List['TrackCredit']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.credits,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['TrackCredits']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.TrackCredits`: Список участников создания трека.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.track.track_credit import TrackCredit
+
+        cls_data['credits'] = TrackCredit.de_list(cls_data.get('credits'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/track/track_full_info.py
+++ b/yandex_music/track/track_full_info.py
@@ -1,0 +1,56 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import Artist, ClientType, JSONType
+    from yandex_music.track.track import Track
+
+
+@model
+class TrackFullInfo(YandexMusicModel):
+    """Класс, представляющий полную информацию о треке.
+
+    Attributes:
+        track (:obj:`yandex_music.Track`, optional): Трек.
+        similar_tracks (:obj:`list` из :obj:`yandex_music.Track`, optional): Список похожих треков.
+        also_in_albums (:obj:`list` из :obj:`yandex_music.Track`, optional): Список треков из других альбомов.
+        aliases (:obj:`list` из :obj:`str`, optional): Список псевдонимов трека.
+        artists (:obj:`list` из :obj:`yandex_music.Artist`, optional): Список артистов с подробной информацией.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    track: Optional['Track'] = None
+    similar_tracks: Optional[List['Track']] = None
+    also_in_albums: Optional[List['Track']] = None
+    aliases: Optional[List[str]] = None
+    artists: Optional[List['Artist']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.track,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['TrackFullInfo']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.TrackFullInfo`: Полная информация о треке.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Artist, Track
+
+        cls_data['track'] = Track.de_json(cls_data.get('track'), client)
+        cls_data['similar_tracks'] = Track.de_list(cls_data.get('similar_tracks'), client)
+        cls_data['also_in_albums'] = Track.de_list(cls_data.get('also_in_albums'), client)
+        cls_data['artists'] = Artist.de_list(cls_data.get('artists'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/track/track_trailer.py
+++ b/yandex_music/track/track_trailer.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.track.track import Track
+
+
+@model
+class TrackTrailer(YandexMusicModel):
+    """Класс, представляющий трейлер трека.
+
+    Attributes:
+        title (:obj:`str`, optional): Заголовок трейлера.
+        track (:obj:`yandex_music.Track`, optional): Трек.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    title: Optional[str] = None
+    track: Optional['Track'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.title, self.track)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['TrackTrailer']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.TrackTrailer`: Трейлер трека.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Track
+
+        cls_data['track'] = Track.de_json(cls_data.get('track'), client)
+
+        return cls(client=client, **cls_data)


### PR DESCRIPTION
Расширение миксина TracksMixin (tracks.py):
- tracks_credits — GET /tracks/:trackId/credits
- tracks_disclaimer — GET /tracks/:trackId/disclaimer
- tracks_trailer — GET /tracks/:trackId/trailer
- tracks_full_info — GET /tracks/:trackId/full-info

Исправление возвращаемых типов в миксинах (замена result.get() на модели):
- albums_disclaimer: Optional[str] → Optional[Disclaimer]
- albums_similar_entities: List[SimilarEntityItem] → Optional[AlbumSimilarEntities]
- tracks_disclaimer: Optional[str] → Optional[Disclaimer]
- tracks_credits: List[TrackCredit] → Optional[TrackCredits]
- artists_similar: List[Artist] → Optional[ArtistSimilar]
- artists_links: List[ArtistLink] → Optional[ArtistLinks]
- pins: List[Pin] → Optional[PinsList]

Новые модели:
- Disclaimer (yandex_music/) — дисклеймер с информацией об иноагенте
- ForeignAgent (yandex_music/) — статус иноагента (reason, title)
- Fade (yandex_music/track/) — параметры затухания трека
- SmartPreviewParams (yandex_music/track/) — параметры умного превью
- TrackCredit (yandex_music/track/) — информация об участнике создания трека
- TrackCredits (yandex_music/track/) — обёртка ответа со списком участников
- TrackTrailer (yandex_music/track/) — трейлер трека
- TrackFullInfo (yandex_music/track/) — полная информация о треке
- ArtistSimilar (yandex_music/artist/) — похожие артисты с исходным артистом
- ArtistLinks (yandex_music/artist/) — ссылки на страницы артиста
- AlbumSimilarEntities (yandex_music/album/) — похожие сущности для альбома
- PinsList (yandex_music/pin/) — список закреплённых элементов

Новые поля:
- Track: derived_colors, fade, smart_preview_params, special_audio_resources, disclaimers