### PR TITLE
Добавлены маршруты предсохранений альбомов и модель Presaves (#697)

### DIFF
--- a/docs/source/yandex_music.presave.presaves.rst
+++ b/docs/source/yandex_music.presave.presaves.rst
@@ -1,0 +1,7 @@
+yandex\_music.presave.presaves
+==============================
+
+.. automodule:: yandex_music.presave.presaves
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.presave.rst
+++ b/docs/source/yandex_music.presave.rst
@@ -1,0 +1,15 @@
+yandex\_music.presave
+=====================
+
+.. automodule:: yandex_music.presave
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   yandex_music.presave.presaves

--- a/docs/source/yandex_music.rst
+++ b/docs/source/yandex_music.rst
@@ -22,6 +22,7 @@ Subpackages
    yandex_music.landing
    yandex_music.pin
    yandex_music.playlist
+   yandex_music.presave
    yandex_music.queue
    yandex_music.rotor
    yandex_music.search

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -82,6 +82,7 @@ from .test_playlist_absence import TestPlaylistAbsence
 from .test_playlist_id import TestPlaylistId
 from .test_plus import TestPlus
 from .test_poetry_lover_match import TestPoetryLoverMatch
+from .test_presaves import TestPresaves
 from .test_price import TestPrice
 from .test_product import TestProduct
 from .test_promotion import TestPromotion

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,7 @@ from yandex_music import (
     PlaylistId,
     Plus,
     PoetryLoverMatch,
+    Presaves,
     Price,
     Product,
     Promotion,
@@ -1537,6 +1538,14 @@ def pin_playlist(pin_data_playlist):
 def pins_list(pin_artist):
     return PinsList(
         pins=[pin_artist],
+    )
+
+
+@pytest.fixture(scope='session')
+def presaves(album):
+    return Presaves(
+        upcoming_albums=[album],
+        released_albums=[album],
     )
 
 

--- a/tests/test_presaves.py
+++ b/tests/test_presaves.py
@@ -1,0 +1,29 @@
+from yandex_music import Presaves
+
+
+class TestPresaves:
+    def test_expected_value(self, presaves, album):
+        assert presaves.upcoming_albums == [album]
+        assert presaves.released_albums == [album]
+
+    def test_de_json_none(self, client):
+        assert Presaves.de_json({}, client) is None
+
+    def test_de_json_all(self, client, album):
+        json_dict = {
+            'upcomingAlbums': [album.to_dict()],
+            'releasedAlbums': [album.to_dict()],
+        }
+        presaves = Presaves.de_json(json_dict, client)
+
+        assert presaves.upcoming_albums == [album]
+        assert presaves.released_albums == [album]
+
+    def test_equality(self, album):
+        a = Presaves(upcoming_albums=[album], released_albums=[album])
+        b = Presaves(upcoming_albums=None, released_albums=None)
+        c = Presaves(upcoming_albums=[album], released_albums=[album])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/yandex_music/__init__.py
+++ b/yandex_music/__init__.py
@@ -159,6 +159,8 @@ from .wave.wave_agent import WaveAgent
 from .wave.similar_entity_data import SimilarEntityData
 from .wave.similar_entity_item import SimilarEntityItem
 
+from .presave.presaves import Presaves
+
 from .content_restrictions import ContentRestrictions
 from .credit import Credit
 from .credits import Credits
@@ -282,6 +284,7 @@ __all__ = [
     'PlaylistRecommendations',
     'Plus',
     'PoetryLoverMatch',
+    'Presaves',
     'Price',
     'Product',
     'PromoCodeStatus',

--- a/yandex_music/_client/presaves.py
+++ b/yandex_music/_client/presaves.py
@@ -1,0 +1,141 @@
+#################################################################################################
+# THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/presaves.py. DON'T EDIT IT BY HANDS #
+#################################################################################################
+
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+from yandex_music import Presaves
+from yandex_music._client import log
+from yandex_music._client_base import ClientBase, UserIdType
+
+if TYPE_CHECKING:
+    from yandex_music.utils.request import Request
+
+
+class PresavesMixin(ClientBase):
+    """Миксин для методов, связанных с предсохранениями альбомов."""
+
+    _request: 'Request'
+
+    @log
+    def users_presaves(
+        self,
+        include_released: bool = False,
+        include_upcoming: bool = True,
+        user_id: UserIdType = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[Presaves]:
+        """Получение списка предсохранённых альбомов.
+
+        Args:
+            include_released (:obj:`bool`, optional): Включить вышедшие альбомы.
+            include_upcoming (:obj:`bool`, optional): Включить предстоящие альбомы.
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя. Если не указан
+                используется ID текущего пользователя.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Presaves` | :obj:`None`: Список предсохранённых альбомов или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/presaves'
+
+        params = {
+            'includeReleased': str(include_released).lower(),
+            'includeUpcoming': str(include_upcoming).lower(),
+        }
+
+        result = self._request.get(url, params, *args, **kwargs)
+
+        return Presaves.de_json(result, self)
+
+    @log
+    def users_presaves_add(
+        self,
+        album_id: Union[str, int],
+        like_after_release: bool = True,
+        user_id: UserIdType = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> bool:
+        """Предсохранение альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            like_after_release (:obj:`bool`, optional): Автоматически поставить лайк после выхода альбома.
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя. Если не указан
+                используется ID текущего пользователя.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/presaves/add'
+
+        params = {
+            'albumId': album_id,
+            'likeAfterRelease': str(like_after_release).lower(),
+        }
+
+        result = self._request.post(url, params, *args, **kwargs)
+
+        return result == 'ok'
+
+    @log
+    def users_presaves_remove(
+        self,
+        album_id: Union[str, int],
+        user_id: UserIdType = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> bool:
+        """Удаление предсохранения альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя. Если не указан
+                используется ID текущего пользователя.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/presaves/remove'
+
+        params = {
+            'albumId': album_id,
+        }
+
+        result = self._request.post(url, params, *args, **kwargs)
+
+        return result == 'ok'
+
+    # camelCase псевдонимы
+
+    #: Псевдоним для :attr:`users_presaves`
+    usersPresaves = users_presaves
+    #: Псевдоним для :attr:`users_presaves_add`
+    usersPresavesAdd = users_presaves_add
+    #: Псевдоним для :attr:`users_presaves_remove`
+    usersPresavesRemove = users_presaves_remove

--- a/yandex_music/_client_async/presaves.py
+++ b/yandex_music/_client_async/presaves.py
@@ -1,0 +1,137 @@
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+from yandex_music import Presaves
+from yandex_music._client_async import log
+from yandex_music._client_base import ClientBase, UserIdType
+
+if TYPE_CHECKING:
+    from yandex_music.utils.request_async import Request
+
+
+class PresavesMixin(ClientBase):
+    """Миксин для методов, связанных с предсохранениями альбомов."""
+
+    _request: 'Request'
+
+    @log
+    async def users_presaves(
+        self,
+        include_released: bool = False,
+        include_upcoming: bool = True,
+        user_id: UserIdType = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[Presaves]:
+        """Получение списка предсохранённых альбомов.
+
+        Args:
+            include_released (:obj:`bool`, optional): Включить вышедшие альбомы.
+            include_upcoming (:obj:`bool`, optional): Включить предстоящие альбомы.
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя. Если не указан
+                используется ID текущего пользователя.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Presaves` | :obj:`None`: Список предсохранённых альбомов или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/presaves'
+
+        params = {
+            'includeReleased': str(include_released).lower(),
+            'includeUpcoming': str(include_upcoming).lower(),
+        }
+
+        result = await self._request.get(url, params, *args, **kwargs)
+
+        return Presaves.de_json(result, self)
+
+    @log
+    async def users_presaves_add(
+        self,
+        album_id: Union[str, int],
+        like_after_release: bool = True,
+        user_id: UserIdType = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> bool:
+        """Предсохранение альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            like_after_release (:obj:`bool`, optional): Автоматически поставить лайк после выхода альбома.
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя. Если не указан
+                используется ID текущего пользователя.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/presaves/add'
+
+        params = {
+            'albumId': album_id,
+            'likeAfterRelease': str(like_after_release).lower(),
+        }
+
+        result = await self._request.post(url, params, *args, **kwargs)
+
+        return result == 'ok'
+
+    @log
+    async def users_presaves_remove(
+        self,
+        album_id: Union[str, int],
+        user_id: UserIdType = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> bool:
+        """Удаление предсохранения альбома.
+
+        Args:
+            album_id (:obj:`str` | :obj:`int`): Уникальный идентификатор альбома.
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя. Если не указан
+                используется ID текущего пользователя.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`bool`: :obj:`True` при успешном выполнении запроса, иначе :obj:`False`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/presaves/remove'
+
+        params = {
+            'albumId': album_id,
+        }
+
+        result = await self._request.post(url, params, *args, **kwargs)
+
+        return result == 'ok'
+
+    # camelCase псевдонимы
+
+    #: Псевдоним для :attr:`users_presaves`
+    usersPresaves = users_presaves
+    #: Псевдоним для :attr:`users_presaves_add`
+    usersPresavesAdd = users_presaves_add
+    #: Псевдоним для :attr:`users_presaves_remove`
+    usersPresavesRemove = users_presaves_remove

--- a/yandex_music/client.py
+++ b/yandex_music/client.py
@@ -17,6 +17,7 @@ from yandex_music._client.landing import LandingMixin
 from yandex_music._client.likes import LikesMixin
 from yandex_music._client.pins import PinsMixin
 from yandex_music._client.playlists import PlaylistsMixin
+from yandex_music._client.presaves import PresavesMixin
 from yandex_music._client.queue import QueueMixin
 from yandex_music._client.radio import RadioMixin
 from yandex_music._client.search import SearchMixin
@@ -40,6 +41,7 @@ class Client(
     ArtistsMixin,
     LikesMixin,
     PinsMixin,
+    PresavesMixin,
     QueueMixin,
     BatchMixin,
     YandexMusicObject,

--- a/yandex_music/client_async.py
+++ b/yandex_music/client_async.py
@@ -13,6 +13,7 @@ from yandex_music._client_async.landing import LandingMixin
 from yandex_music._client_async.likes import LikesMixin
 from yandex_music._client_async.pins import PinsMixin
 from yandex_music._client_async.playlists import PlaylistsMixin
+from yandex_music._client_async.presaves import PresavesMixin
 from yandex_music._client_async.queue import QueueMixin
 from yandex_music._client_async.radio import RadioMixin
 from yandex_music._client_async.search import SearchMixin
@@ -36,6 +37,7 @@ class ClientAsync(
     ArtistsMixin,
     LikesMixin,
     PinsMixin,
+    PresavesMixin,
     QueueMixin,
     BatchMixin,
     YandexMusicObject,

--- a/yandex_music/presave/presaves.py
+++ b/yandex_music/presave/presaves.py
@@ -1,0 +1,48 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.album.album import Album
+
+
+@model
+class Presaves(YandexMusicModel):
+    """Класс, представляющий список предсохранённых альбомов.
+
+    Attributes:
+        upcoming_albums (:obj:`list` из :obj:`yandex_music.Album`, optional): Список предстоящих альбомов.
+        released_albums (:obj:`list` из :obj:`yandex_music.Album`, optional): Список вышедших альбомов.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    upcoming_albums: Optional[List['Album']] = None
+    released_albums: Optional[List['Album']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.upcoming_albums, self.released_albums)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['Presaves']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.Presaves`: Список предсохранённых альбомов.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Album
+
+        cls_data['upcoming_albums'] = Album.de_list(cls_data.get('upcoming_albums'), client)
+        cls_data['released_albums'] = Album.de_list(cls_data.get('released_albums'), client)
+
+        return cls(client=client, **cls_data)


### PR DESCRIPTION
Новый миксин PresavesMixin (presaves.py):
- users_presaves — GET /users/:userId/presaves (список предсохранённых альбомов)
- users_presaves_add — POST /users/:userId/presaves/add (предсохранение альбома)
- users_presaves_remove — POST /users/:userId/presaves/remove (удаление предсохранения)

Новые модели:
- Presaves (yandex_music/presave/) — список предсохранённых альбомов с полями upcoming_albums и released_albums