### PR TITLE
Добавлены маршруты истории прослушивания и модели MusicHistory

### DIFF
--- a/docs/source/yandex_music.music_history.music_history.rst
+++ b/docs/source/yandex_music.music_history.music_history.rst
@@ -1,0 +1,7 @@
+yandex\_music.music\_history.music\_history
+===========================================
+
+.. automodule:: yandex_music.music_history.music_history
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.music_history.music_history_context_full_model.rst
+++ b/docs/source/yandex_music.music_history.music_history_context_full_model.rst
@@ -1,0 +1,7 @@
+yandex\_music.music\_history.music\_history\_context\_full\_model
+=================================================================
+
+.. automodule:: yandex_music.music_history.music_history_context_full_model
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.music_history.music_history_group.rst
+++ b/docs/source/yandex_music.music_history.music_history_group.rst
@@ -1,0 +1,7 @@
+yandex\_music.music\_history.music\_history\_group
+==================================================
+
+.. automodule:: yandex_music.music_history.music_history_group
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.music_history.music_history_item.rst
+++ b/docs/source/yandex_music.music_history.music_history_item.rst
@@ -1,0 +1,7 @@
+yandex\_music.music\_history.music\_history\_item
+=================================================
+
+.. automodule:: yandex_music.music_history.music_history_item
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.music_history.music_history_item_data.rst
+++ b/docs/source/yandex_music.music_history.music_history_item_data.rst
@@ -1,0 +1,7 @@
+yandex\_music.music\_history.music\_history\_item\_data
+=======================================================
+
+.. automodule:: yandex_music.music_history.music_history_item_data
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.music_history.music_history_item_id.rst
+++ b/docs/source/yandex_music.music_history.music_history_item_id.rst
@@ -1,0 +1,7 @@
+yandex\_music.music\_history.music\_history\_item\_id
+=====================================================
+
+.. automodule:: yandex_music.music_history.music_history_item_id
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.music_history.music_history_items.rst
+++ b/docs/source/yandex_music.music_history.music_history_items.rst
@@ -1,0 +1,7 @@
+yandex\_music.music\_history.music\_history\_items
+==================================================
+
+.. automodule:: yandex_music.music_history.music_history_items
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.music_history.music_history_tab.rst
+++ b/docs/source/yandex_music.music_history.music_history_tab.rst
@@ -1,0 +1,7 @@
+yandex\_music.music\_history.music\_history\_tab
+================================================
+
+.. automodule:: yandex_music.music_history.music_history_tab
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.rst
+++ b/docs/source/yandex_music.rst
@@ -20,6 +20,7 @@ Subpackages
    yandex_music.feed
    yandex_music.genre
    yandex_music.landing
+   yandex_music.music_history
    yandex_music.pin
    yandex_music.playlist
    yandex_music.presave

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -63,6 +63,14 @@ from .test_made_for import TestMadeFor
 from .test_major import TestMajor
 from .test_meta_data import TestMetaData
 from .test_mix_link import TestMixLink
+from .test_music_history import TestMusicHistory
+from .test_music_history_context_full_model import TestMusicHistoryContextFullModel
+from .test_music_history_group import TestMusicHistoryGroup
+from .test_music_history_item import TestMusicHistoryItem
+from .test_music_history_item_data import TestMusicHistoryItemData
+from .test_music_history_item_id import TestMusicHistoryItemId
+from .test_music_history_items import TestMusicHistoryItems
+from .test_music_history_tab import TestMusicHistoryTab
 from .test_non_auto_renewable import TestNonAutoRenewable
 from .test_normalization import TestNormalization
 from .test_open_graph_data import TestOpenGraphData

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,14 @@ from yandex_music import (
     Major,
     MetaData,
     MixLink,
+    MusicHistory,
+    MusicHistoryContextFullModel,
+    MusicHistoryGroup,
+    MusicHistoryItem,
+    MusicHistoryItemData,
+    MusicHistoryItemId,
+    MusicHistoryItems,
+    MusicHistoryTab,
     NonAutoRenewable,
     Normalization,
     OpenGraphData,
@@ -187,6 +195,10 @@ from . import (
     TestMajor,
     TestMetaData,
     TestMixLink,
+    TestMusicHistoryContextFullModel,
+    TestMusicHistoryItem,
+    TestMusicHistoryItemId,
+    TestMusicHistoryTab,
     TestNonAutoRenewable,
     TestNormalization,
     TestOpenGraphData,
@@ -1693,4 +1705,92 @@ def artist_similar(artist):
     return ArtistSimilar(
         artist=artist,
         similar_artists=[artist],
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history_item_id():
+    return MusicHistoryItemId(
+        id=TestMusicHistoryItemId.id,
+        track_id=TestMusicHistoryItemId.track_id,
+        album_id=TestMusicHistoryItemId.album_id,
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history_context_full_model_album(album_without_tracks, artist):
+    return MusicHistoryContextFullModel(
+        album=album_without_tracks,
+        artists=[artist],
+        available=TestMusicHistoryContextFullModel.available,
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history_context_full_model_artist(artist):
+    return MusicHistoryContextFullModel(
+        artist=artist,
+        available=TestMusicHistoryContextFullModel.available,
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history_item_data_track(music_history_item_id, track):
+    return MusicHistoryItemData(
+        item_id=music_history_item_id,
+        full_model=track,
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history_item_data_context(music_history_item_id, music_history_context_full_model_album):
+    return MusicHistoryItemData(
+        item_id=music_history_item_id,
+        full_model=music_history_context_full_model_album,
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history_item_track(music_history_item_data_track):
+    return MusicHistoryItem(
+        type=TestMusicHistoryItem.type_track,
+        data=music_history_item_data_track,
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history_item_album(music_history_item_data_context):
+    return MusicHistoryItem(
+        type=TestMusicHistoryItem.type_album,
+        data=music_history_item_data_context,
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history_group(music_history_item_album, music_history_item_track):
+    return MusicHistoryGroup(
+        context=music_history_item_album,
+        tracks=[music_history_item_track],
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history_tab(music_history_group):
+    return MusicHistoryTab(
+        date=TestMusicHistoryTab.date,
+        items=[music_history_group],
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history(music_history_tab):
+    return MusicHistory(
+        history_tabs=[music_history_tab],
+    )
+
+
+@pytest.fixture(scope='session')
+def music_history_items(music_history_item_track):
+    return MusicHistoryItems(
+        items=[music_history_item_track],
     )

--- a/tests/test_music_history.py
+++ b/tests/test_music_history.py
@@ -1,0 +1,25 @@
+from yandex_music import MusicHistory
+
+
+class TestMusicHistory:
+    def test_expected_value(self, music_history, music_history_tab):
+        assert music_history.history_tabs == [music_history_tab]
+
+    def test_de_json_none(self, client):
+        assert MusicHistory.de_json({}, client) is None
+
+    def test_de_json_all(self, client, music_history_tab):
+        json_dict = {
+            'historyTabs': [music_history_tab.to_dict()],
+        }
+        obj = MusicHistory.de_json(json_dict, client)
+        assert obj.history_tabs == [music_history_tab]
+
+    def test_equality(self, music_history_tab):
+        a = MusicHistory(history_tabs=[music_history_tab])
+        b = MusicHistory(history_tabs=None)
+        c = MusicHistory(history_tabs=[music_history_tab])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_music_history_context_full_model.py
+++ b/tests/test_music_history_context_full_model.py
@@ -1,0 +1,49 @@
+from yandex_music import MusicHistoryContextFullModel
+
+
+class TestMusicHistoryContextFullModel:
+    available = True
+    tracks_count = 335
+    simple_wave_foreground_image_url = 'avatars.mds.yandex.net/get-music-misc/29541/img.64426e93aa320f4f1b4b6338/%%'
+    simple_wave_background_color = '#2AA75B'
+
+    def test_expected_value_album(self, music_history_context_full_model_album, album_without_tracks, artist):
+        assert music_history_context_full_model_album.album == album_without_tracks
+        assert music_history_context_full_model_album.artists == [artist]
+        assert music_history_context_full_model_album.available == self.available
+
+    def test_expected_value_artist(self, music_history_context_full_model_artist, artist):
+        assert music_history_context_full_model_artist.artist == artist
+        assert music_history_context_full_model_artist.available == self.available
+
+    def test_de_json_none(self, client):
+        assert MusicHistoryContextFullModel.de_json({}, client) is None
+
+    def test_de_json_album(self, client, album_without_tracks, artist):
+        json_dict = {
+            'album': album_without_tracks.to_dict(),
+            'artists': [artist.to_dict()],
+            'available': self.available,
+        }
+        obj = MusicHistoryContextFullModel.de_json(json_dict, client)
+        assert obj.album == album_without_tracks
+        assert obj.artists == [artist]
+        assert obj.available == self.available
+
+    def test_de_json_artist(self, client, artist):
+        json_dict = {
+            'artist': artist.to_dict(),
+            'available': self.available,
+        }
+        obj = MusicHistoryContextFullModel.de_json(json_dict, client)
+        assert obj.artist == artist
+        assert obj.available == self.available
+
+    def test_equality(self, album_without_tracks):
+        a = MusicHistoryContextFullModel(album=album_without_tracks)
+        b = MusicHistoryContextFullModel(album=None)
+        c = MusicHistoryContextFullModel(album=album_without_tracks)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_music_history_group.py
+++ b/tests/test_music_history_group.py
@@ -1,0 +1,31 @@
+from yandex_music import MusicHistoryGroup
+
+
+class TestMusicHistoryGroup:
+    def test_expected_value(self, music_history_group, music_history_item_album, music_history_item_track):
+        assert music_history_group.context == music_history_item_album
+        assert music_history_group.tracks == [music_history_item_track]
+
+    def test_de_json_none(self, client):
+        assert MusicHistoryGroup.de_json({}, client) is None
+
+    def test_de_json_all(self, client, music_history_item_album, music_history_item_track):
+        json_dict = {
+            'context': music_history_item_album.to_dict(),
+            'tracks': [music_history_item_track.to_dict()],
+        }
+        obj = MusicHistoryGroup.de_json(json_dict, client)
+        assert obj.context == music_history_item_album
+        assert obj.tracks == [music_history_item_track]
+
+    def test_de_list_none(self, client):
+        assert MusicHistoryGroup.de_list([], client) == []
+
+    def test_equality(self, music_history_item_album):
+        a = MusicHistoryGroup(context=music_history_item_album)
+        b = MusicHistoryGroup(context=None)
+        c = MusicHistoryGroup(context=music_history_item_album)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_music_history_item.py
+++ b/tests/test_music_history_item.py
@@ -1,0 +1,55 @@
+from yandex_music import MusicHistoryItem
+
+
+class TestMusicHistoryItem:
+    type_track = 'track'
+    type_album = 'album'
+
+    def test_expected_value_track(self, music_history_item_track, music_history_item_data_track):
+        assert music_history_item_track.type == self.type_track
+        assert music_history_item_track.data == music_history_item_data_track
+
+    def test_expected_value_album(self, music_history_item_album, music_history_item_data_context):
+        assert music_history_item_album.type == self.type_album
+        assert music_history_item_album.data == music_history_item_data_context
+
+    def test_de_json_none(self, client):
+        assert MusicHistoryItem.de_json({}, client) is None
+
+    def test_de_json_track(self, client, music_history_item_id, track):
+        json_dict = {
+            'type': self.type_track,
+            'data': {
+                'itemId': music_history_item_id.to_dict(),
+                'fullModel': track.to_dict(),
+            },
+        }
+        obj = MusicHistoryItem.de_json(json_dict, client)
+        assert obj.type == self.type_track
+        assert obj.data.item_id == music_history_item_id
+        assert obj.data.full_model == track
+
+    def test_de_json_album(self, client, music_history_item_id, music_history_context_full_model_album):
+        json_dict = {
+            'type': self.type_album,
+            'data': {
+                'itemId': music_history_item_id.to_dict(),
+                'fullModel': music_history_context_full_model_album.to_dict(),
+            },
+        }
+        obj = MusicHistoryItem.de_json(json_dict, client)
+        assert obj.type == self.type_album
+        assert obj.data.item_id == music_history_item_id
+        assert obj.data.full_model == music_history_context_full_model_album
+
+    def test_de_list_none(self, client):
+        assert MusicHistoryItem.de_list([], client) == []
+
+    def test_equality(self, music_history_item_data_track):
+        a = MusicHistoryItem(type=self.type_track, data=music_history_item_data_track)
+        b = MusicHistoryItem(type=self.type_album, data=music_history_item_data_track)
+        c = MusicHistoryItem(type=self.type_track, data=music_history_item_data_track)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_music_history_item_data.py
+++ b/tests/test_music_history_item_data.py
@@ -1,0 +1,43 @@
+from yandex_music import MusicHistoryItemData
+
+
+class TestMusicHistoryItemData:
+    def test_expected_value_track(self, music_history_item_data_track, music_history_item_id, track):
+        assert music_history_item_data_track.item_id == music_history_item_id
+        assert music_history_item_data_track.full_model == track
+
+    def test_expected_value_context(
+        self, music_history_item_data_context, music_history_item_id, music_history_context_full_model_album
+    ):
+        assert music_history_item_data_context.item_id == music_history_item_id
+        assert music_history_item_data_context.full_model == music_history_context_full_model_album
+
+    def test_de_json_none(self, client):
+        assert MusicHistoryItemData.de_json({}, client) is None
+
+    def test_de_json_track(self, client, music_history_item_id, track):
+        json_dict = {
+            'itemId': music_history_item_id.to_dict(),
+            'fullModel': track.to_dict(),
+        }
+        obj = MusicHistoryItemData.de_json(json_dict, client, item_type='track')
+        assert obj.item_id == music_history_item_id
+        assert obj.full_model == track
+
+    def test_de_json_album(self, client, music_history_item_id, music_history_context_full_model_album):
+        json_dict = {
+            'itemId': music_history_item_id.to_dict(),
+            'fullModel': music_history_context_full_model_album.to_dict(),
+        }
+        obj = MusicHistoryItemData.de_json(json_dict, client, item_type='album')
+        assert obj.item_id == music_history_item_id
+        assert obj.full_model == music_history_context_full_model_album
+
+    def test_equality(self, music_history_item_id):
+        a = MusicHistoryItemData(item_id=music_history_item_id)
+        b = MusicHistoryItemData(item_id=None)
+        c = MusicHistoryItemData(item_id=music_history_item_id)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_music_history_item_id.py
+++ b/tests/test_music_history_item_id.py
@@ -1,0 +1,52 @@
+from yandex_music import MusicHistoryItemId
+
+
+class TestMusicHistoryItemId:
+    id = '12345'
+    track_id = '67890'
+    album_id = '54321'
+    uid = 100500
+    kind = 3
+    seeds = ['user:onyourwave']
+
+    def test_expected_value(self, music_history_item_id):
+        assert music_history_item_id.id == self.id
+        assert music_history_item_id.track_id == self.track_id
+        assert music_history_item_id.album_id == self.album_id
+
+    def test_de_json_none(self, client):
+        assert MusicHistoryItemId.de_json({}, client) is None
+
+    def test_de_json_track(self, client):
+        json_dict = {
+            'trackId': self.track_id,
+            'albumId': self.album_id,
+        }
+        item_id = MusicHistoryItemId.de_json(json_dict, client)
+        assert item_id.track_id == self.track_id
+        assert item_id.album_id == self.album_id
+
+    def test_de_json_album(self, client):
+        json_dict = {'id': self.id}
+        item_id = MusicHistoryItemId.de_json(json_dict, client)
+        assert item_id.id == self.id
+
+    def test_de_json_playlist(self, client):
+        json_dict = {'uid': self.uid, 'kind': self.kind}
+        item_id = MusicHistoryItemId.de_json(json_dict, client)
+        assert item_id.uid == self.uid
+        assert item_id.kind == self.kind
+
+    def test_de_json_wave(self, client):
+        json_dict = {'seeds': self.seeds}
+        item_id = MusicHistoryItemId.de_json(json_dict, client)
+        assert item_id.seeds == self.seeds
+
+    def test_equality(self):
+        a = MusicHistoryItemId(id=self.id, track_id=self.track_id, album_id=self.album_id)
+        b = MusicHistoryItemId(id='other')
+        c = MusicHistoryItemId(id=self.id, track_id=self.track_id, album_id=self.album_id)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_music_history_items.py
+++ b/tests/test_music_history_items.py
@@ -1,0 +1,25 @@
+from yandex_music import MusicHistoryItems
+
+
+class TestMusicHistoryItems:
+    def test_expected_value(self, music_history_items, music_history_item_track):
+        assert music_history_items.items == [music_history_item_track]
+
+    def test_de_json_none(self, client):
+        assert MusicHistoryItems.de_json({}, client) is None
+
+    def test_de_json_all(self, client, music_history_item_track):
+        json_dict = {
+            'items': [music_history_item_track.to_dict()],
+        }
+        obj = MusicHistoryItems.de_json(json_dict, client)
+        assert obj.items == [music_history_item_track]
+
+    def test_equality(self, music_history_item_track):
+        a = MusicHistoryItems(items=[music_history_item_track])
+        b = MusicHistoryItems(items=None)
+        c = MusicHistoryItems(items=[music_history_item_track])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_music_history_tab.py
+++ b/tests/test_music_history_tab.py
@@ -1,0 +1,33 @@
+from yandex_music import MusicHistoryTab
+
+
+class TestMusicHistoryTab:
+    date = '2025-01-15'
+
+    def test_expected_value(self, music_history_tab, music_history_group):
+        assert music_history_tab.date == self.date
+        assert music_history_tab.items == [music_history_group]
+
+    def test_de_json_none(self, client):
+        assert MusicHistoryTab.de_json({}, client) is None
+
+    def test_de_json_all(self, client, music_history_group):
+        json_dict = {
+            'date': self.date,
+            'items': [music_history_group.to_dict()],
+        }
+        obj = MusicHistoryTab.de_json(json_dict, client)
+        assert obj.date == self.date
+        assert obj.items == [music_history_group]
+
+    def test_de_list_none(self, client):
+        assert MusicHistoryTab.de_list([], client) == []
+
+    def test_equality(self):
+        a = MusicHistoryTab(date=self.date)
+        b = MusicHistoryTab(date='2025-02-01')
+        c = MusicHistoryTab(date=self.date)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/yandex_music/__init__.py
+++ b/yandex_music/__init__.py
@@ -159,6 +159,15 @@ from .wave.wave_agent import WaveAgent
 from .wave.similar_entity_data import SimilarEntityData
 from .wave.similar_entity_item import SimilarEntityItem
 
+from .music_history.music_history_item_id import MusicHistoryItemId
+from .music_history.music_history_context_full_model import MusicHistoryContextFullModel
+from .music_history.music_history_item_data import MusicHistoryItemData
+from .music_history.music_history_item import MusicHistoryItem
+from .music_history.music_history_group import MusicHistoryGroup
+from .music_history.music_history_tab import MusicHistoryTab
+from .music_history.music_history import MusicHistory
+from .music_history.music_history_items import MusicHistoryItems
+
 from .presave.presaves import Presaves
 
 from .content_restrictions import ContentRestrictions
@@ -263,6 +272,14 @@ __all__ = [
     'MapTypeToDeJson',
     'MetaData',
     'MixLink',
+    'MusicHistory',
+    'MusicHistoryContextFullModel',
+    'MusicHistoryGroup',
+    'MusicHistoryItem',
+    'MusicHistoryItemData',
+    'MusicHistoryItemId',
+    'MusicHistoryItems',
+    'MusicHistoryTab',
     'NonAutoRenewable',
     'Normalization',
     'OpenGraphData',

--- a/yandex_music/_client/music_history.py
+++ b/yandex_music/_client/music_history.py
@@ -1,0 +1,116 @@
+######################################################################################################
+# THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/music_history.py. DON'T EDIT IT BY HANDS #
+######################################################################################################
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+from yandex_music import MusicHistory, MusicHistoryItems
+from yandex_music._client import log
+from yandex_music._client_base import ClientBase
+
+if TYPE_CHECKING:
+    from yandex_music.utils.request import Request
+
+
+def _make_item(type_: str, item_id: Dict[str, Any]) -> Dict[str, Any]:
+    return {'type': type_, 'data': {'itemId': item_id}}
+
+
+def _build_history_items(
+    track_ids: Optional[List[Tuple[Union[str, int], Union[str, int]]]] = None,
+    album_ids: Optional[List[Union[str, int]]] = None,
+    artist_ids: Optional[List[Union[str, int]]] = None,
+    playlist_ids: Optional[List[Tuple[Union[str, int], Union[str, int]]]] = None,
+    wave_seeds: Optional[List[List[str]]] = None,
+) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    for track_id, album_id in track_ids or []:
+        items.append(_make_item('track', {'trackId': str(track_id), 'albumId': str(album_id)}))
+    for album_id in album_ids or []:
+        items.append(_make_item('album', {'id': str(album_id)}))
+    for artist_id in artist_ids or []:
+        items.append(_make_item('artist', {'id': str(artist_id)}))
+    for uid, kind in playlist_ids or []:
+        items.append(_make_item('playlist', {'uid': int(uid), 'kind': int(kind)}))
+    for seeds in wave_seeds or []:
+        items.append(_make_item('wave', {'seeds': seeds}))
+    return items
+
+
+class MusicHistoryMixin(ClientBase):
+    """Миксин для методов, связанных с историей прослушивания."""
+
+    _request: 'Request'
+
+    @log
+    def music_history(
+        self,
+        full_models_count: int = 0,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[MusicHistory]:
+        """Получение истории прослушивания.
+
+        Args:
+            full_models_count (:obj:`int`, optional): Количество полных моделей для возврата.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.MusicHistory` | :obj:`None`: История прослушивания или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/music-history'
+
+        params = {
+            'fullModelsCount': full_models_count,
+        }
+
+        result = self._request.get(url, params, *args, **kwargs)
+
+        return MusicHistory.de_json(result, self)
+
+    @log
+    def music_history_items(
+        self,
+        track_ids: Optional[List[Tuple[Union[str, int], Union[str, int]]]] = None,
+        album_ids: Optional[List[Union[str, int]]] = None,
+        artist_ids: Optional[List[Union[str, int]]] = None,
+        playlist_ids: Optional[List[Tuple[Union[str, int], Union[str, int]]]] = None,
+        wave_seeds: Optional[List[List[str]]] = None,
+        **kwargs: Any,
+    ) -> Optional[MusicHistoryItems]:
+        """Получение элементов истории прослушивания по списку идентификаторов.
+
+        Args:
+            track_ids (:obj:`list` из :obj:`tuple`, optional): Список пар (track_id, album_id).
+            album_ids (:obj:`list` из :obj:`str` | :obj:`int`, optional): Список идентификаторов альбомов.
+            artist_ids (:obj:`list` из :obj:`str` | :obj:`int`, optional): Список идентификаторов исполнителей.
+            playlist_ids (:obj:`list` из :obj:`tuple`, optional): Список пар (uid, kind).
+            wave_seeds (:obj:`list` из :obj:`list`, optional): Список массивов семян волны
+                (например, ``[['user:onyourwave']]``).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.MusicHistoryItems` | :obj:`None`: Результат запроса
+                элементов истории или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/music-history/items'
+
+        items = _build_history_items(track_ids, album_ids, artist_ids, playlist_ids, wave_seeds)
+
+        result = self._request.post(url, json={'items': items}, **kwargs)
+
+        return MusicHistoryItems.de_json(result, self)
+
+    # camelCase псевдонимы
+
+    #: Псевдоним для :attr:`music_history`
+    musicHistory = music_history
+    #: Псевдоним для :attr:`music_history_items`
+    musicHistoryItems = music_history_items

--- a/yandex_music/_client_async/music_history.py
+++ b/yandex_music/_client_async/music_history.py
@@ -1,0 +1,112 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+from yandex_music import MusicHistory, MusicHistoryItems
+from yandex_music._client_async import log
+from yandex_music._client_base import ClientBase
+
+if TYPE_CHECKING:
+    from yandex_music.utils.request_async import Request
+
+
+def _make_item(type_: str, item_id: Dict[str, Any]) -> Dict[str, Any]:
+    return {'type': type_, 'data': {'itemId': item_id}}
+
+
+def _build_history_items(
+    track_ids: Optional[List[Tuple[Union[str, int], Union[str, int]]]] = None,
+    album_ids: Optional[List[Union[str, int]]] = None,
+    artist_ids: Optional[List[Union[str, int]]] = None,
+    playlist_ids: Optional[List[Tuple[Union[str, int], Union[str, int]]]] = None,
+    wave_seeds: Optional[List[List[str]]] = None,
+) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+    for track_id, album_id in track_ids or []:
+        items.append(_make_item('track', {'trackId': str(track_id), 'albumId': str(album_id)}))
+    for album_id in album_ids or []:
+        items.append(_make_item('album', {'id': str(album_id)}))
+    for artist_id in artist_ids or []:
+        items.append(_make_item('artist', {'id': str(artist_id)}))
+    for uid, kind in playlist_ids or []:
+        items.append(_make_item('playlist', {'uid': int(uid), 'kind': int(kind)}))
+    for seeds in wave_seeds or []:
+        items.append(_make_item('wave', {'seeds': seeds}))
+    return items
+
+
+class MusicHistoryMixin(ClientBase):
+    """Миксин для методов, связанных с историей прослушивания."""
+
+    _request: 'Request'
+
+    @log
+    async def music_history(
+        self,
+        full_models_count: int = 0,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[MusicHistory]:
+        """Получение истории прослушивания.
+
+        Args:
+            full_models_count (:obj:`int`, optional): Количество полных моделей для возврата.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.MusicHistory` | :obj:`None`: История прослушивания или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/music-history'
+
+        params = {
+            'fullModelsCount': full_models_count,
+        }
+
+        result = await self._request.get(url, params, *args, **kwargs)
+
+        return MusicHistory.de_json(result, self)
+
+    @log
+    async def music_history_items(
+        self,
+        track_ids: Optional[List[Tuple[Union[str, int], Union[str, int]]]] = None,
+        album_ids: Optional[List[Union[str, int]]] = None,
+        artist_ids: Optional[List[Union[str, int]]] = None,
+        playlist_ids: Optional[List[Tuple[Union[str, int], Union[str, int]]]] = None,
+        wave_seeds: Optional[List[List[str]]] = None,
+        **kwargs: Any,
+    ) -> Optional[MusicHistoryItems]:
+        """Получение элементов истории прослушивания по списку идентификаторов.
+
+        Args:
+            track_ids (:obj:`list` из :obj:`tuple`, optional): Список пар (track_id, album_id).
+            album_ids (:obj:`list` из :obj:`str` | :obj:`int`, optional): Список идентификаторов альбомов.
+            artist_ids (:obj:`list` из :obj:`str` | :obj:`int`, optional): Список идентификаторов исполнителей.
+            playlist_ids (:obj:`list` из :obj:`tuple`, optional): Список пар (uid, kind).
+            wave_seeds (:obj:`list` из :obj:`list`, optional): Список массивов семян волны
+                (например, ``[['user:onyourwave']]``).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.MusicHistoryItems` | :obj:`None`: Результат запроса
+                элементов истории или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/music-history/items'
+
+        items = _build_history_items(track_ids, album_ids, artist_ids, playlist_ids, wave_seeds)
+
+        result = await self._request.post(url, json={'items': items}, **kwargs)
+
+        return MusicHistoryItems.de_json(result, self)
+
+    # camelCase псевдонимы
+
+    #: Псевдоним для :attr:`music_history`
+    musicHistory = music_history
+    #: Псевдоним для :attr:`music_history_items`
+    musicHistoryItems = music_history_items

--- a/yandex_music/album/album.py
+++ b/yandex_music/album/album.py
@@ -119,6 +119,7 @@ class Album(YandexMusicModel):
     deprecation: Optional['Deprecation'] = None
     available_regions: Optional[List[str]] = None
     available_for_options: Optional[List[str]] = None
+    listening_finished: Optional[bool] = None
     client: Optional['ClientType'] = None
 
     def __post_init__(self) -> None:

--- a/yandex_music/client.py
+++ b/yandex_music/client.py
@@ -15,6 +15,7 @@ from yandex_music._client.credits import CreditsMixin
 from yandex_music._client.disclaimers import DisclaimersMixin
 from yandex_music._client.landing import LandingMixin
 from yandex_music._client.likes import LikesMixin
+from yandex_music._client.music_history import MusicHistoryMixin
 from yandex_music._client.pins import PinsMixin
 from yandex_music._client.playlists import PlaylistsMixin
 from yandex_music._client.presaves import PresavesMixin
@@ -40,6 +41,7 @@ class Client(
     RadioMixin,
     ArtistsMixin,
     LikesMixin,
+    MusicHistoryMixin,
     PinsMixin,
     PresavesMixin,
     QueueMixin,

--- a/yandex_music/client_async.py
+++ b/yandex_music/client_async.py
@@ -11,6 +11,7 @@ from yandex_music._client_async.credits import CreditsMixin
 from yandex_music._client_async.disclaimers import DisclaimersMixin
 from yandex_music._client_async.landing import LandingMixin
 from yandex_music._client_async.likes import LikesMixin
+from yandex_music._client_async.music_history import MusicHistoryMixin
 from yandex_music._client_async.pins import PinsMixin
 from yandex_music._client_async.playlists import PlaylistsMixin
 from yandex_music._client_async.presaves import PresavesMixin
@@ -36,6 +37,7 @@ class ClientAsync(
     RadioMixin,
     ArtistsMixin,
     LikesMixin,
+    MusicHistoryMixin,
     PinsMixin,
     PresavesMixin,
     QueueMixin,

--- a/yandex_music/music_history/music_history.py
+++ b/yandex_music/music_history/music_history.py
@@ -1,0 +1,46 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.music_history.music_history_tab import MusicHistoryTab
+
+
+@model
+class MusicHistory(YandexMusicModel):
+    """Класс, представляющий историю прослушивания.
+
+    Attributes:
+        history_tabs (:obj:`list` из :obj:`yandex_music.MusicHistoryTab`, optional):
+            Список вкладок (дней) истории прослушивания.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    history_tabs: Optional[List['MusicHistoryTab']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.history_tabs,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MusicHistory']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MusicHistory`: История прослушивания.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.music_history.music_history_tab import MusicHistoryTab
+
+        cls_data['history_tabs'] = MusicHistoryTab.de_list(cls_data.get('history_tabs'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/music_history/music_history_context_full_model.py
+++ b/yandex_music/music_history/music_history_context_full_model.py
@@ -1,0 +1,72 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import Album, Artist, ClientType, JSONType, Playlist, Wave
+
+
+@model
+class MusicHistoryContextFullModel(YandexMusicModel):
+    """Класс, представляющий полную модель контекста истории прослушивания.
+
+    Note:
+        Набор заполненных полей зависит от типа контекста:
+
+        - ``album``: `album`, `artists`, `available`.
+        - ``artist``: `artist`, `available`.
+        - ``playlist``: `playlist`, `available`, `tracks_count`.
+        - ``wave``: `wave`, `simple_wave_foreground_image_url`, `simple_wave_background_color`.
+
+    Attributes:
+        album (:obj:`yandex_music.Album`, optional): Альбом контекста.
+        artist (:obj:`yandex_music.Artist`, optional): Исполнитель контекста.
+        playlist (:obj:`yandex_music.Playlist`, optional): Плейлист контекста.
+        wave (:obj:`yandex_music.Wave`, optional): Волна контекста.
+        artists (:obj:`list` из :obj:`yandex_music.Artist`, optional): Список исполнителей (для альбома).
+        available (:obj:`bool`, optional): Доступность.
+        tracks_count (:obj:`int`, optional): Количество треков (для плейлиста).
+        simple_wave_foreground_image_url (:obj:`str`, optional): URL изображения волны.
+        simple_wave_background_color (:obj:`str`, optional): Цвет фона волны.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    album: Optional['Album'] = None
+    artist: Optional['Artist'] = None
+    playlist: Optional['Playlist'] = None
+    wave: Optional['Wave'] = None
+    artists: Optional[List['Artist']] = None
+    available: Optional[bool] = None
+    tracks_count: Optional[int] = None
+    simple_wave_foreground_image_url: Optional[str] = None
+    simple_wave_background_color: Optional[str] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.album, self.artist, self.playlist, self.wave)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MusicHistoryContextFullModel']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MusicHistoryContextFullModel`: Полная модель контекста истории прослушивания.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Album, Artist, Playlist, Wave
+
+        cls_data['album'] = Album.de_json(cls_data.get('album'), client)
+        cls_data['artist'] = Artist.de_json(cls_data.get('artist'), client)
+        cls_data['playlist'] = Playlist.de_json(cls_data.get('playlist'), client)
+        cls_data['wave'] = Wave.de_json(cls_data.get('wave'), client)
+        cls_data['artists'] = Artist.de_list(cls_data.get('artists'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/music_history/music_history_group.py
+++ b/yandex_music/music_history/music_history_group.py
@@ -1,0 +1,52 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.music_history.music_history_item import MusicHistoryItem
+
+
+@model
+class MusicHistoryGroup(YandexMusicModel):
+    """Класс, представляющий группу элементов истории прослушивания.
+
+    Note:
+        Группа содержит контекст (например, альбом) и список прослушанных треков
+        в рамках этого контекста.
+
+    Attributes:
+        context (:obj:`yandex_music.MusicHistoryItem`, optional): Контекст прослушивания (альбом, плейлист и т.д.).
+        tracks (:obj:`list` из :obj:`yandex_music.MusicHistoryItem`, optional): Список прослушанных треков.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    context: Optional['MusicHistoryItem'] = None
+    tracks: Optional[List['MusicHistoryItem']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.context,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MusicHistoryGroup']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MusicHistoryGroup`: Группа элементов истории прослушивания.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.music_history.music_history_item import MusicHistoryItem
+
+        cls_data['context'] = MusicHistoryItem.de_json(cls_data.get('context'), client)
+        cls_data['tracks'] = MusicHistoryItem.de_list(cls_data.get('tracks'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/music_history/music_history_item.py
+++ b/yandex_music/music_history/music_history_item.py
@@ -1,0 +1,51 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.music_history.music_history_item_data import MusicHistoryItemData
+
+
+@model
+class MusicHistoryItem(YandexMusicModel):
+    """Класс, представляющий элемент истории прослушивания.
+
+    Note:
+        Известные значения поля `type`: ``track``, ``album``.
+
+    Attributes:
+        type (:obj:`str`): Тип элемента.
+        data (:obj:`yandex_music.MusicHistoryItemData`, optional): Данные элемента.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    type: str
+    data: Optional['MusicHistoryItemData'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.type, self.data)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MusicHistoryItem']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MusicHistoryItem`: Элемент истории прослушивания.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.music_history.music_history_item_data import MusicHistoryItemData
+
+        item_type = cls_data.get('type')
+        cls_data['data'] = MusicHistoryItemData.de_json(cls_data.get('data'), client, item_type=item_type)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/music_history/music_history_item_data.py
+++ b/yandex_music/music_history/music_history_item_data.py
@@ -1,0 +1,67 @@
+from typing import TYPE_CHECKING, Optional, Union
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType, Track
+    from yandex_music.music_history.music_history_context_full_model import MusicHistoryContextFullModel
+    from yandex_music.music_history.music_history_item_id import MusicHistoryItemId
+
+
+@model
+class MusicHistoryItemData(YandexMusicModel):
+    """Класс, представляющий данные элемента истории прослушивания.
+
+    Note:
+        Поле `full_model` содержит :obj:`yandex_music.Track` для элементов типа ``track``
+        и :obj:`yandex_music.MusicHistoryContextFullModel` для элементов типа ``album``.
+
+    Attributes:
+        item_id (:obj:`yandex_music.MusicHistoryItemId`, optional): Идентификатор элемента.
+        full_model (:obj:`yandex_music.Track` | :obj:`yandex_music.MusicHistoryContextFullModel`, optional):
+            Полная модель элемента.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    item_id: Optional['MusicHistoryItemId'] = None
+    full_model: Optional[Union['Track', 'MusicHistoryContextFullModel']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.item_id,)
+
+    @classmethod
+    def de_json(
+        cls,
+        data: 'JSONType',
+        client: 'ClientType',
+        item_type: Optional[str] = None,
+    ) -> Optional['MusicHistoryItemData']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+            item_type (:obj:`str`, optional): Тип элемента (``track`` или ``album``),
+                определяет тип десериализации поля `full_model`.
+
+        Returns:
+            :obj:`yandex_music.MusicHistoryItemData`: Данные элемента истории прослушивания.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Track
+        from yandex_music.music_history.music_history_context_full_model import MusicHistoryContextFullModel
+        from yandex_music.music_history.music_history_item_id import MusicHistoryItemId
+
+        cls_data['item_id'] = MusicHistoryItemId.de_json(cls_data.get('item_id'), client)
+
+        if item_type == 'track':
+            cls_data['full_model'] = Track.de_json(cls_data.get('full_model'), client)
+        else:
+            cls_data['full_model'] = MusicHistoryContextFullModel.de_json(cls_data.get('full_model'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/music_history/music_history_item_id.py
+++ b/yandex_music/music_history/music_history_item_id.py
@@ -1,0 +1,41 @@
+from typing import TYPE_CHECKING, List, Optional, Union
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class MusicHistoryItemId(YandexMusicModel):
+    """Класс, представляющий идентификатор элемента истории прослушивания.
+
+    Note:
+        Набор заполненных полей зависит от типа элемента:
+
+        - ``album`` / ``artist``: `id`.
+        - ``track``: `track_id` и `album_id`.
+        - ``playlist``: `uid` и `kind`.
+        - ``wave``: `seeds`.
+
+    Attributes:
+        id (:obj:`str`, optional): Идентификатор альбома или исполнителя.
+        track_id (:obj:`str`, optional): Идентификатор трека.
+        album_id (:obj:`str`, optional): Идентификатор альбома трека.
+        uid (:obj:`int`, optional): Идентификатор владельца плейлиста.
+        kind (:obj:`int`, optional): Идентификатор плейлиста.
+        seeds (:obj:`list` из :obj:`str`, optional): Семена волны.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    id: Optional[str] = None
+    track_id: Optional[str] = None
+    album_id: Optional[str] = None
+    uid: Optional[Union[str, int]] = None
+    kind: Optional[Union[str, int]] = None
+    seeds: Optional[List[str]] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.id, self.track_id, self.album_id, self.uid, self.kind, self.seeds)

--- a/yandex_music/music_history/music_history_items.py
+++ b/yandex_music/music_history/music_history_items.py
@@ -1,0 +1,45 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.music_history.music_history_item import MusicHistoryItem
+
+
+@model
+class MusicHistoryItems(YandexMusicModel):
+    """Класс, представляющий результат запроса элементов истории прослушивания.
+
+    Attributes:
+        items (:obj:`list` из :obj:`yandex_music.MusicHistoryItem`, optional): Список элементов истории.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    items: Optional[List['MusicHistoryItem']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.items,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MusicHistoryItems']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MusicHistoryItems`: Результат запроса элементов истории прослушивания.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.music_history.music_history_item import MusicHistoryItem
+
+        cls_data['items'] = MusicHistoryItem.de_list(cls_data.get('items'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/music_history/music_history_tab.py
+++ b/yandex_music/music_history/music_history_tab.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.music_history.music_history_group import MusicHistoryGroup
+
+
+@model
+class MusicHistoryTab(YandexMusicModel):
+    """Класс, представляющий вкладку (день) истории прослушивания.
+
+    Attributes:
+        date (:obj:`str`, optional): Дата в формате ``YYYY-MM-DD``.
+        items (:obj:`list` из :obj:`yandex_music.MusicHistoryGroup`, optional): Список групп прослушивания за день.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    date: Optional[str] = None
+    items: Optional[List['MusicHistoryGroup']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.date,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MusicHistoryTab']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MusicHistoryTab`: Вкладка истории прослушивания.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music.music_history.music_history_group import MusicHistoryGroup
+
+        cls_data['items'] = MusicHistoryGroup.de_list(cls_data.get('items'), client)
+
+        return cls(client=client, **cls_data)


### PR DESCRIPTION
Добавлены маршруты истории прослушивания и модели MusicHistory

Новый миксин MusicHistoryMixin (music_history.py):

- music_history — GET /music-history?fullModelsCount=
- music_history_items — POST /music-history/items (JSON body: {items: [{type, data: {itemId}}]})

Новые модели (yandex_music/music_history/):
- MusicHistory — обёртка ответа GET /music-history (history_tabs)
- MusicHistoryTab — вкладка (день) с датой и группами
- MusicHistoryGroup — группа: контекст + треки
- MusicHistoryItem — элемент с типом (track/album/artist/playlist/wave) и данными
- MusicHistoryItemData — данные элемента: item_id + full_model (полиморфный по типу)
- MusicHistoryItemId — идентификатор: id (альбом/исполнитель), track_id+album_id (трек), uid+kind (плейлист), seeds (волна)
- MusicHistoryContextFullModel — полная модель контекста: album+artists, artist, playlist+tracks_count, wave+foreground/background
- MusicHistoryItems — обёртка ответа POST /music-history/items

Поддерживаемые типы контекста:

- album: album, artists, available
- artist: artist, available
- playlist: playlist, available, tracks_count
- wave: wave, simple_wave_foreground_image_url, simple_wave_background_color

closes #315 and #674