### PR TITLE
Добавлены расширенные маршруты плейлистов и новые модели

### DIFF
--- a/docs/source/yandex_music.album.rst
+++ b/docs/source/yandex_music.album.rst
@@ -18,4 +18,3 @@ Submodules
    yandex_music.album.deprecation
    yandex_music.album.label
    yandex_music.album.track_position
-   yandex_music.album.trailer_info

--- a/docs/source/yandex_music.album.trailer_info.rst
+++ b/docs/source/yandex_music.album.trailer_info.rst
@@ -1,7 +1,0 @@
-yandex\_music.album.trailer\_info
-=================================
-
-.. automodule:: yandex_music.album.trailer_info
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/yandex_music.playlist.playlist_availability.rst
+++ b/docs/source/yandex_music.playlist.playlist_availability.rst
@@ -1,0 +1,7 @@
+yandex\_music.playlist.playlist\_availability
+=============================================
+
+.. automodule:: yandex_music.playlist.playlist_availability
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.playlist.playlist_similar_entities.rst
+++ b/docs/source/yandex_music.playlist.playlist_similar_entities.rst
@@ -1,0 +1,7 @@
+yandex\_music.playlist.playlist\_similar\_entities
+==================================================
+
+.. automodule:: yandex_music.playlist.playlist_similar_entities
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.playlist.playlist_trailer.rst
+++ b/docs/source/yandex_music.playlist.playlist_trailer.rst
@@ -1,0 +1,7 @@
+yandex\_music.playlist.playlist\_trailer
+========================================
+
+.. automodule:: yandex_music.playlist.playlist_trailer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.playlist.playlists_list.rst
+++ b/docs/source/yandex_music.playlist.playlists_list.rst
@@ -1,0 +1,7 @@
+yandex\_music.playlist.playlists\_list
+======================================
+
+.. automodule:: yandex_music.playlist.playlists_list
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.playlist.rst
+++ b/docs/source/yandex_music.playlist.rst
@@ -21,8 +21,12 @@ Submodules
    yandex_music.playlist.play_counter
    yandex_music.playlist.playlist
    yandex_music.playlist.playlist_absence
+   yandex_music.playlist.playlist_availability
    yandex_music.playlist.playlist_id
    yandex_music.playlist.playlist_recommendation
+   yandex_music.playlist.playlist_similar_entities
+   yandex_music.playlist.playlist_trailer
+   yandex_music.playlist.playlists_list
    yandex_music.playlist.tag
    yandex_music.playlist.tag_result
    yandex_music.playlist.user

--- a/docs/source/yandex_music.rst
+++ b/docs/source/yandex_music.rst
@@ -61,4 +61,5 @@ Submodules
    yandex_music.settings
    yandex_music.track_short
    yandex_music.tracks_list
+   yandex_music.trailer_info
    yandex_music.video

--- a/docs/source/yandex_music.trailer_info.rst
+++ b/docs/source/yandex_music.trailer_info.rst
@@ -1,0 +1,7 @@
+yandex\_music.trailer\_info
+===========================
+
+.. automodule:: yandex_music.trailer_info
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -104,7 +104,11 @@ from .test_play_contexts_data import TestPlayContextsData
 from .test_play_counter import TestPlayCounter
 from .test_playlist import TestPlaylist
 from .test_playlist_absence import TestPlaylistAbsence
+from .test_playlist_availability import TestPlaylistAvailability
 from .test_playlist_id import TestPlaylistId
+from .test_playlist_similar_entities import TestPlaylistSimilarEntities
+from .test_playlist_trailer import TestPlaylistTrailer
+from .test_playlists_list import TestPlaylistsList
 from .test_plus import TestPlus
 from .test_poetry_lover_match import TestPoetryLoverMatch
 from .test_presaves import TestPresaves

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,11 @@ from yandex_music import (
     PlayCounter,
     Playlist,
     PlaylistAbsence,
+    PlaylistAvailability,
     PlaylistId,
+    PlaylistSimilarEntities,
+    PlaylistsList,
+    PlaylistTrailer,
     Plus,
     PoetryLoverMatch,
     Presaves,
@@ -243,7 +247,9 @@ from . import (
     TestPlayCounter,
     TestPlaylist,
     TestPlaylistAbsence,
+    TestPlaylistAvailability,
     TestPlaylistId,
+    TestPlaylistTrailer,
     TestPlus,
     TestPoetryLoverMatch,
     TestPrice,
@@ -1974,4 +1980,34 @@ def artist_donation_item(artist_donation_data):
 def artist_donations(artist_donation_item):
     return ArtistDonations(
         donations=[artist_donation_item],
+    )
+
+
+@pytest.fixture(scope='session')
+def playlist_availability():
+    return PlaylistAvailability(
+        available=TestPlaylistAvailability.available,
+    )
+
+
+@pytest.fixture(scope='session')
+def playlist_trailer(playlist, trailer_info):
+    return PlaylistTrailer(
+        playlist=playlist,
+        trailer=trailer_info,
+        shareable=TestPlaylistTrailer.shareable,
+    )
+
+
+@pytest.fixture(scope='session')
+def playlist_similar_entities(similar_entity_item):
+    return PlaylistSimilarEntities(
+        items=[similar_entity_item],
+    )
+
+
+@pytest.fixture(scope='session')
+def playlists_list(playlist):
+    return PlaylistsList(
+        playlists=[playlist],
     )

--- a/tests/test_custom_wave.py
+++ b/tests/test_custom_wave.py
@@ -5,6 +5,10 @@ class TestCustomWave:
     title = 'В стиле: Трибунал'
     animation_url = 'https://music-custom-wave-media.s3.yandex.net/base.json'
     position = 'default'
+    header = 'Моя волна по плейлисту'
+    background_image_url = (
+        'avatars.mds.yandex.net/get-music-misc/28052/custom-wave-default-playlist-background.image/%%'
+    )
 
     def test_expected_values(self, custom_wave):
         assert custom_wave.title == self.title
@@ -31,12 +35,16 @@ class TestCustomWave:
             'title': self.title,
             'animation_url': self.animation_url,
             'position': self.position,
+            'header': self.header,
+            'backgroundImageUrl': self.background_image_url,
         }
         customwave = CustomWave.de_json(json_dict, client)
 
         assert customwave.title == self.title
         assert customwave.animation_url == self.animation_url
         assert customwave.position == self.position
+        assert customwave.header == self.header
+        assert customwave.background_image_url == self.background_image_url
 
     def test_equality(self):
         a = CustomWave(self.title, self.animation_url, self.position)

--- a/tests/test_playlist_availability.py
+++ b/tests/test_playlist_availability.py
@@ -1,0 +1,28 @@
+from yandex_music import PlaylistAvailability
+
+
+class TestPlaylistAvailability:
+    available = False
+
+    def test_expected_values(self, playlist_availability):
+        assert playlist_availability.available == self.available
+
+    def test_de_json_none(self, client):
+        assert PlaylistAvailability.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'available': self.available,
+        }
+        playlist_availability = PlaylistAvailability.de_json(json_dict, client)
+
+        assert playlist_availability.available == self.available
+
+    def test_equality(self):
+        a = PlaylistAvailability(available=False)
+        b = PlaylistAvailability(available=True)
+        c = PlaylistAvailability(available=False)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_playlist_similar_entities.py
+++ b/tests/test_playlist_similar_entities.py
@@ -1,0 +1,26 @@
+from yandex_music import PlaylistSimilarEntities
+
+
+class TestPlaylistSimilarEntities:
+    def test_expected_value(self, playlist_similar_entities, similar_entity_item):
+        assert playlist_similar_entities.items == [similar_entity_item]
+
+    def test_de_json_none(self, client):
+        assert PlaylistSimilarEntities.de_json({}, client) is None
+
+    def test_de_json_all(self, client, similar_entity_item):
+        json_dict = {
+            'items': [similar_entity_item.to_dict()],
+        }
+        playlist_similar_entities = PlaylistSimilarEntities.de_json(json_dict, client)
+
+        assert playlist_similar_entities.items == [similar_entity_item]
+
+    def test_equality(self, similar_entity_item):
+        a = PlaylistSimilarEntities(items=[similar_entity_item])
+        b = PlaylistSimilarEntities(items=None)
+        c = PlaylistSimilarEntities(items=[similar_entity_item])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_playlist_trailer.py
+++ b/tests/test_playlist_trailer.py
@@ -1,0 +1,34 @@
+from yandex_music import PlaylistTrailer
+
+
+class TestPlaylistTrailer:
+    shareable = False
+
+    def test_expected_values(self, playlist_trailer, playlist, trailer_info):
+        assert playlist_trailer.playlist == playlist
+        assert playlist_trailer.trailer == trailer_info
+        assert playlist_trailer.shareable == self.shareable
+
+    def test_de_json_none(self, client):
+        assert PlaylistTrailer.de_json({}, client) is None
+
+    def test_de_json_all(self, client, playlist, trailer_info):
+        json_dict = {
+            'playlist': playlist.to_dict(),
+            'trailer': trailer_info.to_dict(),
+            'shareable': self.shareable,
+        }
+        playlist_trailer = PlaylistTrailer.de_json(json_dict, client)
+
+        assert playlist_trailer.playlist == playlist
+        assert playlist_trailer.trailer == trailer_info
+        assert playlist_trailer.shareable == self.shareable
+
+    def test_equality(self, playlist, trailer_info):
+        a = PlaylistTrailer(playlist=playlist, trailer=trailer_info)
+        b = PlaylistTrailer(playlist=None, trailer=trailer_info)
+        c = PlaylistTrailer(playlist=playlist, trailer=trailer_info)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/tests/test_playlists_list.py
+++ b/tests/test_playlists_list.py
@@ -1,0 +1,26 @@
+from yandex_music import PlaylistsList
+
+
+class TestPlaylistsList:
+    def test_expected_value(self, playlists_list, playlist):
+        assert playlists_list.playlists == [playlist]
+
+    def test_de_json_none(self, client):
+        assert PlaylistsList.de_json({}, client) is None
+
+    def test_de_json_all(self, client, playlist):
+        json_dict = {
+            'playlists': [playlist.to_dict()],
+        }
+        playlists_list = PlaylistsList.de_json(json_dict, client)
+
+        assert playlists_list.playlists == [playlist]
+
+    def test_equality(self, playlist):
+        a = PlaylistsList(playlists=[playlist])
+        b = PlaylistsList(playlists=None)
+        c = PlaylistsList(playlists=[playlist])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a == c

--- a/yandex_music/__init__.py
+++ b/yandex_music/__init__.py
@@ -30,7 +30,7 @@ from .album.album_similar_entities import AlbumSimilarEntities
 from .album.album_trailer import AlbumTrailer
 from .album.label import Label
 from .album.track_position import TrackPosition
-from .album.trailer_info import TrailerInfo
+from .trailer_info import TrailerInfo
 from .album.deprecation import Deprecation
 
 from .artist.about_artist import ArtistAbout
@@ -85,8 +85,12 @@ from .playlist.playlist_id import PlaylistId
 from .playlist.tag import Tag
 from .playlist.tag_result import TagResult
 from .playlist.playlist_absence import PlaylistAbsence
+from .playlist.playlist_availability import PlaylistAvailability
 from .playlist.playlist import Playlist
 from .playlist.playlist_recommendation import PlaylistRecommendations
+from .playlist.playlist_similar_entities import PlaylistSimilarEntities
+from .playlist.playlist_trailer import PlaylistTrailer
+from .playlist.playlists_list import PlaylistsList
 
 from .shot.shot_type import ShotType
 from .shot.shot_data import ShotData
@@ -331,8 +335,12 @@ __all__ = [
     'PlayCounter',
     'Playlist',
     'PlaylistAbsence',
+    'PlaylistAvailability',
     'PlaylistId',
     'PlaylistRecommendations',
+    'PlaylistSimilarEntities',
+    'PlaylistTrailer',
+    'PlaylistsList',
     'Plus',
     'PoetryLoverMatch',
     'Presaves',

--- a/yandex_music/_client/playlists.py
+++ b/yandex_music/_client/playlists.py
@@ -4,7 +4,15 @@
 
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from yandex_music import Playlist, PlaylistRecommendations, UserSettings
+from yandex_music import (
+    GeneratedPlaylist,
+    Playlist,
+    PlaylistRecommendations,
+    PlaylistSimilarEntities,
+    PlaylistsList,
+    PlaylistTrailer,
+    UserSettings,
+)
 from yandex_music._client import log
 from yandex_music._client_base import ClientBase, UserIdType, is_dict
 from yandex_music.utils.difference import Difference
@@ -422,6 +430,196 @@ class PlaylistsMixin(ClientBase):
 
         return list(Playlist.de_list(result, self))
 
+    @log
+    def playlist(self, playlist_uuid: str, *args: Any, **kwargs: Any) -> Optional[Playlist]:
+        """Получение плейлиста по его UUID.
+
+        Args:
+            playlist_uuid (:obj:`str`): UUID плейлиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Playlist` | :obj:`None`: Плейлист или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/playlist/{playlist_uuid}'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return Playlist.de_json(result, self)
+
+    @log
+    def playlist_similar_entities(
+        self, playlist_uuid: str, *args: Any, **kwargs: Any
+    ) -> Optional[PlaylistSimilarEntities]:
+        """Получение похожих сущностей для плейлиста.
+
+        Args:
+            playlist_uuid (:obj:`str`): UUID плейлиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.PlaylistSimilarEntities` | :obj:`None`: Похожие сущности или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/playlist/{playlist_uuid}/similar-entities'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return PlaylistSimilarEntities.de_json(result, self)
+
+    @log
+    def playlists(self, playlist_ids: Union[List[str], str], *args: Any, **kwargs: Any) -> Optional[PlaylistsList]:
+        """Получение списка плейлистов по идентификаторам.
+
+        Note:
+            Идентификаторы плейлистов имеют формат ``uid:kind`` (например, ``503646255:161344908``).
+
+        Args:
+            playlist_ids (:obj:`str` | :obj:`list` из :obj:`str`): Идентификатор плейлиста или список идентификаторов
+                в формате ``uid:kind``.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.PlaylistsList` | :obj:`None`: Список плейлистов или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/playlists'
+
+        if isinstance(playlist_ids, list):
+            playlist_ids = ','.join(playlist_ids)
+
+        kwargs['params'] = {'playlistIds': playlist_ids}
+        result = self._request.get(url, *args, **kwargs)
+
+        return PlaylistsList.de_json(result, self)
+
+    @log
+    def playlists_personal(self, playlist_id: str, *args: Any, **kwargs: Any) -> Optional[GeneratedPlaylist]:
+        """Получение персонального плейлиста.
+
+        Note:
+            Известные значения ``playlist_id``: ``daily`` (Плейлист дня), ``missedLikes`` (Тайник),
+            ``recentTracks`` (Премьера), ``neverHeard`` (Дежавю), ``podcasts`` (Подкасты недели),
+            ``origin`` (Плейлист с Алисой).
+
+        Args:
+            playlist_id (:obj:`str`): Идентификатор персонального плейлиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.GeneratedPlaylist` | :obj:`None`: Персональный плейлист или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/playlists/personal/{playlist_id}'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return GeneratedPlaylist.de_json(result, self)
+
+    @log
+    def users_playlists_description(
+        self,
+        kind: Union[str, int],
+        description: str,
+        user_id: UserIdType = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[Playlist]:
+        """Изменение описания плейлиста.
+
+        Args:
+            kind (:obj:`str` | :obj:`int`): Уникальный идентификатор плейлиста.
+            description (:obj:`str`): Новое описание.
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя владеющим плейлистом.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Playlist` | :obj:`None`: Изменённый плейлист или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/playlists/{kind}/description'
+
+        result = self._request.post(url, {'value': description}, *args, **kwargs)
+
+        return Playlist.de_json(result, self)
+
+    @log
+    def users_playlists_trailer(
+        self,
+        kind: Union[str, int],
+        user_id: UserIdType = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[PlaylistTrailer]:
+        """Получение трейлера плейлиста.
+
+        Args:
+            kind (:obj:`str` | :obj:`int`): Уникальный идентификатор плейлиста.
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя владеющим плейлистом.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.PlaylistTrailer` | :obj:`None`: Трейлер плейлиста или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/playlists/{kind}/trailer'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return PlaylistTrailer.de_json(result, self)
+
+    @log
+    def users_playlists_kinds(self, user_id: UserIdType = None, *args: Any, **kwargs: Any) -> List[int]:
+        """Получение списка идентификаторов (kind) плейлистов пользователя.
+
+        Args:
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя. Если не указан
+                используется ID текущего пользователя.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`int`: Список идентификаторов плейлистов.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/playlists/list/kinds'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        if isinstance(result, list):
+            return result
+        return []
+
     # camelCase псевдонимы
 
     #: Псевдоним для :attr:`users_settings`
@@ -448,3 +646,13 @@ class PlaylistsMixin(ClientBase):
     playlistsCollectiveJoin = playlists_collective_join
     #: Псевдоним для :attr:`users_playlists_list`
     usersPlaylistsList = users_playlists_list
+    #: Псевдоним для :attr:`playlist_similar_entities`
+    playlistSimilarEntities = playlist_similar_entities
+    #: Псевдоним для :attr:`playlists_personal`
+    playlistsPersonal = playlists_personal
+    #: Псевдоним для :attr:`users_playlists_description`
+    usersPlaylistsDescription = users_playlists_description
+    #: Псевдоним для :attr:`users_playlists_trailer`
+    usersPlaylistsTrailer = users_playlists_trailer
+    #: Псевдоним для :attr:`users_playlists_kinds`
+    usersPlaylistsKinds = users_playlists_kinds

--- a/yandex_music/_client_async/playlists.py
+++ b/yandex_music/_client_async/playlists.py
@@ -1,6 +1,14 @@
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
-from yandex_music import Playlist, PlaylistRecommendations, UserSettings
+from yandex_music import (
+    GeneratedPlaylist,
+    Playlist,
+    PlaylistRecommendations,
+    PlaylistSimilarEntities,
+    PlaylistsList,
+    PlaylistTrailer,
+    UserSettings,
+)
 from yandex_music._client_async import log
 from yandex_music._client_base import ClientBase, UserIdType, is_dict
 from yandex_music.utils.difference import Difference
@@ -418,6 +426,198 @@ class PlaylistsMixin(ClientBase):
 
         return list(Playlist.de_list(result, self))
 
+    @log
+    async def playlist(self, playlist_uuid: str, *args: Any, **kwargs: Any) -> Optional[Playlist]:
+        """Получение плейлиста по его UUID.
+
+        Args:
+            playlist_uuid (:obj:`str`): UUID плейлиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Playlist` | :obj:`None`: Плейлист или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/playlist/{playlist_uuid}'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return Playlist.de_json(result, self)
+
+    @log
+    async def playlist_similar_entities(
+        self, playlist_uuid: str, *args: Any, **kwargs: Any
+    ) -> Optional[PlaylistSimilarEntities]:
+        """Получение похожих сущностей для плейлиста.
+
+        Args:
+            playlist_uuid (:obj:`str`): UUID плейлиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.PlaylistSimilarEntities` | :obj:`None`: Похожие сущности или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/playlist/{playlist_uuid}/similar-entities'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return PlaylistSimilarEntities.de_json(result, self)
+
+    @log
+    async def playlists(
+        self, playlist_ids: Union[List[str], str], *args: Any, **kwargs: Any
+    ) -> Optional[PlaylistsList]:
+        """Получение списка плейлистов по идентификаторам.
+
+        Note:
+            Идентификаторы плейлистов имеют формат ``uid:kind`` (например, ``503646255:161344908``).
+
+        Args:
+            playlist_ids (:obj:`str` | :obj:`list` из :obj:`str`): Идентификатор плейлиста или список идентификаторов
+                в формате ``uid:kind``.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.PlaylistsList` | :obj:`None`: Список плейлистов или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/playlists'
+
+        if isinstance(playlist_ids, list):
+            playlist_ids = ','.join(playlist_ids)
+
+        kwargs['params'] = {'playlistIds': playlist_ids}
+        result = await self._request.get(url, *args, **kwargs)
+
+        return PlaylistsList.de_json(result, self)
+
+    @log
+    async def playlists_personal(self, playlist_id: str, *args: Any, **kwargs: Any) -> Optional[GeneratedPlaylist]:
+        """Получение персонального плейлиста.
+
+        Note:
+            Известные значения ``playlist_id``: ``daily`` (Плейлист дня), ``missedLikes`` (Тайник),
+            ``recentTracks`` (Премьера), ``neverHeard`` (Дежавю), ``podcasts`` (Подкасты недели),
+            ``origin`` (Плейлист с Алисой).
+
+        Args:
+            playlist_id (:obj:`str`): Идентификатор персонального плейлиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.GeneratedPlaylist` | :obj:`None`: Персональный плейлист или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/playlists/personal/{playlist_id}'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return GeneratedPlaylist.de_json(result, self)
+
+    @log
+    async def users_playlists_description(
+        self,
+        kind: Union[str, int],
+        description: str,
+        user_id: UserIdType = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[Playlist]:
+        """Изменение описания плейлиста.
+
+        Args:
+            kind (:obj:`str` | :obj:`int`): Уникальный идентификатор плейлиста.
+            description (:obj:`str`): Новое описание.
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя владеющим плейлистом.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Playlist` | :obj:`None`: Изменённый плейлист или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/playlists/{kind}/description'
+
+        result = await self._request.post(url, {'value': description}, *args, **kwargs)
+
+        return Playlist.de_json(result, self)
+
+    @log
+    async def users_playlists_trailer(
+        self,
+        kind: Union[str, int],
+        user_id: UserIdType = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[PlaylistTrailer]:
+        """Получение трейлера плейлиста.
+
+        Args:
+            kind (:obj:`str` | :obj:`int`): Уникальный идентификатор плейлиста.
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя владеющим плейлистом.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.PlaylistTrailer` | :obj:`None`: Трейлер плейлиста или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/playlists/{kind}/trailer'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return PlaylistTrailer.de_json(result, self)
+
+    @log
+    async def users_playlists_kinds(self, user_id: UserIdType = None, *args: Any, **kwargs: Any) -> List[int]:
+        """Получение списка идентификаторов (kind) плейлистов пользователя.
+
+        Args:
+            user_id (:obj:`str` | :obj:`int`, optional): Уникальный идентификатор пользователя. Если не указан
+                используется ID текущего пользователя.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`list` из :obj:`int`: Список идентификаторов плейлистов.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        if user_id is None and self.account_uid is not None:
+            user_id = self.account_uid
+
+        url = f'{self.base_url}/users/{user_id}/playlists/list/kinds'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        if isinstance(result, list):
+            return result
+        return []
+
     # camelCase псевдонимы
 
     #: Псевдоним для :attr:`users_settings`
@@ -444,3 +644,13 @@ class PlaylistsMixin(ClientBase):
     playlistsCollectiveJoin = playlists_collective_join
     #: Псевдоним для :attr:`users_playlists_list`
     usersPlaylistsList = users_playlists_list
+    #: Псевдоним для :attr:`playlist_similar_entities`
+    playlistSimilarEntities = playlist_similar_entities
+    #: Псевдоним для :attr:`playlists_personal`
+    playlistsPersonal = playlists_personal
+    #: Псевдоним для :attr:`users_playlists_description`
+    usersPlaylistsDescription = users_playlists_description
+    #: Псевдоним для :attr:`users_playlists_trailer`
+    usersPlaylistsTrailer = users_playlists_trailer
+    #: Псевдоним для :attr:`users_playlists_kinds`
+    usersPlaylistsKinds = users_playlists_kinds

--- a/yandex_music/album/album_trailer.py
+++ b/yandex_music/album/album_trailer.py
@@ -6,8 +6,8 @@ from yandex_music.utils import model
 if TYPE_CHECKING:
     from yandex_music import ClientType, JSONType
     from yandex_music.album.album import Album
-    from yandex_music.album.trailer_info import TrailerInfo
     from yandex_music.artist.artist import Artist
+    from yandex_music.trailer_info import TrailerInfo
 
 
 @model
@@ -45,7 +45,7 @@ class AlbumTrailer(YandexMusicModel):
 
         cls_data = cls.cleanup_data(data, client)
         from yandex_music import Album, Artist
-        from yandex_music.album.trailer_info import TrailerInfo
+        from yandex_music.trailer_info import TrailerInfo
 
         cls_data['album'] = Album.de_json(cls_data.get('album'), client)
         cls_data['artists'] = Artist.de_list(cls_data.get('artists'), client)

--- a/yandex_music/playlist/custom_wave.py
+++ b/yandex_music/playlist/custom_wave.py
@@ -18,12 +18,16 @@ class CustomWave(YandexMusicModel):
         title (:obj:`str`): Название плейлиста.
         animation_url (:obj:`str`): JSON анимация Lottie.
         position (:obj:`str`): Позиция TODO.
+        header (:obj:`str`, optional): Заголовок волны.
+        background_image_url (:obj:`str`, optional): Ссылка на фоновое изображение.
         client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
     """
 
     title: str
     animation_url: str
     position: str
+    header: Optional[str] = None
+    background_image_url: Optional[str] = None
     client: Optional['ClientType'] = None
 
     def __post_init__(self) -> None:

--- a/yandex_music/playlist/playlist.py
+++ b/yandex_music/playlist/playlist.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         TrackShort,
         User,
     )
+    from yandex_music.playlist.playlist_availability import PlaylistAvailability
 
 
 @model
@@ -100,6 +101,11 @@ class Playlist(YandexMusicModel):
         regions: Регион TODO.
         custom_wave (:obj:'yandex_music.CustomWave`, optional): Описание плейлиста. TODO.
         pager (:obj:`yandex_music.Pager`, optional): Пагинатор.
+        has_trailer (:obj:`bool`, optional): Есть ли у плейлиста трейлер.
+        trailer (:obj:`yandex_music.PlaylistAvailability`, optional): Доступность трейлера плейлиста.
+        background_video_url (:obj:`str`, optional): Ссылка на фоновое видео.
+        background_video_id (:obj:`str`, optional): Идентификатор фонового видео.
+        background_image_url (:obj:`str`, optional): Ссылка на фоновое изображение.
         client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
     """
 
@@ -160,6 +166,11 @@ class Playlist(YandexMusicModel):
     regions: Any = None
     custom_wave: Optional['CustomWave'] = None
     pager: Optional['Pager'] = None
+    has_trailer: Optional[bool] = None
+    trailer: Optional['PlaylistAvailability'] = None
+    background_video_url: Optional[str] = None
+    background_video_id: Optional[str] = None
+    background_image_url: Optional[str] = None
     client: Optional['ClientType'] = None
 
     def __post_init__(self) -> None:
@@ -539,6 +550,10 @@ class Playlist(YandexMusicModel):
 
         cls_data['custom_wave'] = CustomWave.de_json(cls_data.get('custom_wave'), client)
         cls_data['pager'] = Pager.de_json(cls_data.get('pager'), client)
+
+        from yandex_music.playlist.playlist_availability import PlaylistAvailability
+
+        cls_data['trailer'] = PlaylistAvailability.de_json(cls_data.get('trailer'), client)
 
         return cls(client=client, **cls_data)  # type: ignore
 

--- a/yandex_music/playlist/playlist_availability.py
+++ b/yandex_music/playlist/playlist_availability.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class PlaylistAvailability(YandexMusicModel):
+    """Класс, представляющий доступность трейлера плейлиста.
+
+    Attributes:
+        available (:obj:`bool`, optional): Доступен ли трейлер.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    available: Optional[bool] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.available,)

--- a/yandex_music/playlist/playlist_similar_entities.py
+++ b/yandex_music/playlist/playlist_similar_entities.py
@@ -1,0 +1,44 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType, SimilarEntityItem
+
+
+@model
+class PlaylistSimilarEntities(YandexMusicModel):
+    """Класс, представляющий похожие сущности для плейлиста.
+
+    Attributes:
+        items (:obj:`list` из :obj:`yandex_music.SimilarEntityItem`, optional): Список похожих сущностей.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    items: Optional[List['SimilarEntityItem']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.items,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['PlaylistSimilarEntities']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.PlaylistSimilarEntities`: Похожие сущности для плейлиста.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import SimilarEntityItem
+
+        cls_data['items'] = SimilarEntityItem.de_list(cls_data.get('items'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/playlist/playlist_trailer.py
+++ b/yandex_music/playlist/playlist_trailer.py
@@ -5,29 +5,31 @@ from yandex_music.utils import model
 
 if TYPE_CHECKING:
     from yandex_music import ClientType, JSONType
-    from yandex_music.artist.artist import Artist
+    from yandex_music.playlist.playlist import Playlist
     from yandex_music.trailer_info import TrailerInfo
 
 
 @model
-class ArtistTrailer(YandexMusicModel):
-    """Класс, представляющий трейлер артиста.
+class PlaylistTrailer(YandexMusicModel):
+    """Класс, представляющий трейлер плейлиста.
 
     Attributes:
-        artist (:obj:`yandex_music.Artist`, optional): Артист.
+        playlist (:obj:`yandex_music.Playlist`, optional): Плейлист.
         trailer (:obj:`yandex_music.TrailerInfo`, optional): Информация о трейлере.
+        shareable (:obj:`bool`, optional): Можно ли поделиться трейлером.
         client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
     """
 
-    artist: Optional['Artist'] = None
+    playlist: Optional['Playlist'] = None
     trailer: Optional['TrailerInfo'] = None
+    shareable: Optional[bool] = None
     client: Optional['ClientType'] = None
 
     def __post_init__(self) -> None:
-        self._id_attrs = (self.artist, self.trailer)
+        self._id_attrs = (self.playlist, self.trailer)
 
     @classmethod
-    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['ArtistTrailer']:
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['PlaylistTrailer']:
         """Десериализация объекта.
 
         Args:
@@ -35,16 +37,16 @@ class ArtistTrailer(YandexMusicModel):
             client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
 
         Returns:
-            :obj:`yandex_music.ArtistTrailer`: Трейлер артиста.
+            :obj:`yandex_music.PlaylistTrailer`: Трейлер плейлиста.
         """
         if not cls.is_dict_model_data(data):
             return None
 
         cls_data = cls.cleanup_data(data, client)
-        from yandex_music import Artist
+        from yandex_music import Playlist
         from yandex_music.trailer_info import TrailerInfo
 
-        cls_data['artist'] = Artist.de_json(cls_data.get('artist'), client)
+        cls_data['playlist'] = Playlist.de_json(cls_data.get('playlist'), client)
         cls_data['trailer'] = TrailerInfo.de_json(cls_data.get('trailer'), client)
 
         return cls(client=client, **cls_data)

--- a/yandex_music/playlist/playlists_list.py
+++ b/yandex_music/playlist/playlists_list.py
@@ -5,28 +5,26 @@ from yandex_music.utils import model
 
 if TYPE_CHECKING:
     from yandex_music import ClientType, JSONType
-    from yandex_music.track.track import Track
+    from yandex_music.playlist.playlist import Playlist
 
 
 @model
-class TrailerInfo(YandexMusicModel):
-    """Класс, представляющий информацию о трейлере альбома.
+class PlaylistsList(YandexMusicModel):
+    """Класс, представляющий список плейлистов.
 
     Attributes:
-        title (:obj:`str`, optional): Заголовок трейлера.
-        tracks (:obj:`list` из :obj:`yandex_music.Track`, optional): Список треков трейлера.
+        playlists (:obj:`list` из :obj:`yandex_music.Playlist`, optional): Список плейлистов.
         client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
     """
 
-    title: Optional[str] = None
-    tracks: Optional[List['Track']] = None
+    playlists: Optional[List['Playlist']] = None
     client: Optional['ClientType'] = None
 
     def __post_init__(self) -> None:
-        self._id_attrs = (self.title, self.tracks)
+        self._id_attrs = (self.playlists,)
 
     @classmethod
-    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['TrailerInfo']:
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['PlaylistsList']:
         """Десериализация объекта.
 
         Args:
@@ -34,14 +32,14 @@ class TrailerInfo(YandexMusicModel):
             client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
 
         Returns:
-            :obj:`yandex_music.TrailerInfo`: Информация о трейлере альбома.
+            :obj:`yandex_music.PlaylistsList`: Список плейлистов.
         """
         if not cls.is_dict_model_data(data):
             return None
 
         cls_data = cls.cleanup_data(data, client)
-        from yandex_music import Track
+        from yandex_music import Playlist
 
-        cls_data['tracks'] = Track.de_list(cls_data.get('tracks'), client)
+        cls_data['playlists'] = Playlist.de_list(cls_data.get('playlists'), client)
 
         return cls(client=client, **cls_data)

--- a/yandex_music/trailer_info.py
+++ b/yandex_music/trailer_info.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+    from yandex_music.track.track import Track
+
+
+@model
+class TrailerInfo(YandexMusicModel):
+    """Класс, представляющий информацию о трейлере.
+
+    Attributes:
+        title (:obj:`str`, optional): Заголовок трейлера.
+        tracks (:obj:`list` из :obj:`yandex_music.Track`, optional): Список треков трейлера.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    title: Optional[str] = None
+    tracks: Optional[List['Track']] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.title, self.tracks)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['TrailerInfo']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.TrailerInfo`: Информация о трейлере.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Track
+
+        cls_data['tracks'] = Track.de_list(cls_data.get('tracks'), client)
+
+        return cls(client=client, **cls_data)


### PR DESCRIPTION
Расширенный миксин PlaylistsMixin (playlists.py):
- playlist — GET /playlist/:playlistUuid
- playlist_similar_entities — GET /playlist/:playlistUuid/similar-entities
- playlists — GET /playlists?playlistIds=
- playlists_personal — GET /playlists/personal/:playlistId
- users_playlists_description — POST /users/:userId/playlists/:kind/description
- users_playlists_trailer — GET /users/:userId/playlists/:kind/trailer
- users_playlists_kinds — GET /users/:userId/playlists/list/kinds

Новые модели:
- PlaylistAvailability (yandex_music/playlist/) — доступность трейлера
- PlaylistTrailer (yandex_music/playlist/) — трейлер плейлиста с playlist, trailer (TrailerInfo) и shareable
- PlaylistSimilarEntities (yandex_music/playlist/) — похожие сущности плейлиста
- PlaylistsList (yandex_music/playlist/) — обёртка ответа GET /playlists

playlists_personal возвращает GeneratedPlaylist (type, ready, notify, data), playlists возвращает PlaylistsList — ответы API десериализуются целиком.

Новые поля:
- Playlist: has_trailer, trailer (PlaylistAvailability), background_video_url, background_video_id, background_image_url
- CustomWave: header, background_image_url

Рефакторинг:
- TrailerInfo перенесён из album/ в корень yandex_music/ — используется альбомами, артистами и плейлистами