### PR TITLE
Добавлены маршруты метатегов и новый миксин MetatagsMixin

### DIFF
--- a/docs/source/client.md
+++ b/docs/source/client.md
@@ -43,6 +43,7 @@ client = Client().init()
    yandex_music._client.labels
    yandex_music._client.landing
    yandex_music._client.likes
+   yandex_music._client.metatags
    yandex_music._client.music_history
    yandex_music._client.pins
    yandex_music._client.playlists

--- a/docs/source/client_async.md
+++ b/docs/source/client_async.md
@@ -67,6 +67,7 @@ await full_track.download()
    yandex_music._client_async.labels
    yandex_music._client_async.landing
    yandex_music._client_async.likes
+   yandex_music._client_async.metatags
    yandex_music._client_async.music_history
    yandex_music._client_async.pins
    yandex_music._client_async.playlists

--- a/docs/source/yandex_music._client.metatags.rst
+++ b/docs/source/yandex_music._client.metatags.rst
@@ -1,0 +1,6 @@
+Метатеги
+========
+
+.. automodule:: yandex_music._client.metatags
+   :members:
+   :undoc-members:

--- a/docs/source/yandex_music._client.rst
+++ b/docs/source/yandex_music._client.rst
@@ -23,6 +23,7 @@ Submodules
    yandex_music._client.labels
    yandex_music._client.landing
    yandex_music._client.likes
+   yandex_music._client.metatags
    yandex_music._client.music_history
    yandex_music._client.pins
    yandex_music._client.playlists

--- a/docs/source/yandex_music._client_async.metatags.rst
+++ b/docs/source/yandex_music._client_async.metatags.rst
@@ -1,0 +1,6 @@
+Метатеги
+========
+
+.. automodule:: yandex_music._client_async.metatags
+   :members:
+   :undoc-members:

--- a/docs/source/yandex_music._client_async.rst
+++ b/docs/source/yandex_music._client_async.rst
@@ -23,6 +23,7 @@ Submodules
    yandex_music._client_async.labels
    yandex_music._client_async.landing
    yandex_music._client_async.likes
+   yandex_music._client_async.metatags
    yandex_music._client_async.music_history
    yandex_music._client_async.pins
    yandex_music._client_async.playlists

--- a/docs/source/yandex_music.metatag.metatag.rst
+++ b/docs/source/yandex_music.metatag.metatag.rst
@@ -1,0 +1,7 @@
+yandex\_music.metatag.metatag
+=============================
+
+.. automodule:: yandex_music.metatag.metatag
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.metatag.metatag_albums.rst
+++ b/docs/source/yandex_music.metatag.metatag_albums.rst
@@ -1,0 +1,7 @@
+yandex\_music.metatag.metatag\_albums
+=====================================
+
+.. automodule:: yandex_music.metatag.metatag_albums
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.metatag.metatag_artist_entry.rst
+++ b/docs/source/yandex_music.metatag.metatag_artist_entry.rst
@@ -1,0 +1,7 @@
+yandex\_music.metatag.metatag\_artist\_entry
+============================================
+
+.. automodule:: yandex_music.metatag.metatag_artist_entry
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.metatag.metatag_artists.rst
+++ b/docs/source/yandex_music.metatag.metatag_artists.rst
@@ -1,0 +1,7 @@
+yandex\_music.metatag.metatag\_artists
+======================================
+
+.. automodule:: yandex_music.metatag.metatag_artists
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.metatag.metatag_leaf.rst
+++ b/docs/source/yandex_music.metatag.metatag_leaf.rst
@@ -1,0 +1,7 @@
+yandex\_music.metatag.metatag\_leaf
+===================================
+
+.. automodule:: yandex_music.metatag.metatag_leaf
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.metatag.metatag_playlists.rst
+++ b/docs/source/yandex_music.metatag.metatag_playlists.rst
@@ -1,0 +1,7 @@
+yandex\_music.metatag.metatag\_playlists
+========================================
+
+.. automodule:: yandex_music.metatag.metatag_playlists
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.metatag.metatag_sort_by_value.rst
+++ b/docs/source/yandex_music.metatag.metatag_sort_by_value.rst
@@ -1,0 +1,7 @@
+yandex\_music.metatag.metatag\_sort\_by\_value
+==============================================
+
+.. automodule:: yandex_music.metatag.metatag_sort_by_value
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.metatag.metatag_title.rst
+++ b/docs/source/yandex_music.metatag.metatag_title.rst
@@ -1,0 +1,7 @@
+yandex\_music.metatag.metatag\_title
+====================================
+
+.. automodule:: yandex_music.metatag.metatag_title
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.metatag.metatag_tree.rst
+++ b/docs/source/yandex_music.metatag.metatag_tree.rst
@@ -1,0 +1,7 @@
+yandex\_music.metatag.metatag\_tree
+===================================
+
+.. automodule:: yandex_music.metatag.metatag_tree
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.metatag.metatags.rst
+++ b/docs/source/yandex_music.metatag.metatags.rst
@@ -1,0 +1,7 @@
+yandex\_music.metatag.metatags
+==============================
+
+.. automodule:: yandex_music.metatag.metatags
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.metatag.rst
+++ b/docs/source/yandex_music.metatag.rst
@@ -1,0 +1,24 @@
+yandex\_music.metatag
+=====================
+
+.. automodule:: yandex_music.metatag
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   yandex_music.metatag.metatag
+   yandex_music.metatag.metatag_albums
+   yandex_music.metatag.metatag_artist_entry
+   yandex_music.metatag.metatag_artists
+   yandex_music.metatag.metatag_leaf
+   yandex_music.metatag.metatag_playlists
+   yandex_music.metatag.metatag_sort_by_value
+   yandex_music.metatag.metatag_title
+   yandex_music.metatag.metatag_tree
+   yandex_music.metatag.metatags

--- a/docs/source/yandex_music.rst
+++ b/docs/source/yandex_music.rst
@@ -21,6 +21,7 @@ Subpackages
    yandex_music.genre
    yandex_music.label
    yandex_music.landing
+   yandex_music.metatag
    yandex_music.music_history
    yandex_music.pin
    yandex_music.playlist

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -88,6 +88,16 @@ from .test_lyrics_major import TestLyricsMajor
 from .test_made_for import TestMadeFor
 from .test_major import TestMajor
 from .test_meta_data import TestMetaData
+from .test_metatag import TestMetatag
+from .test_metatag_albums import TestMetatagAlbums
+from .test_metatag_artist_entry import TestMetatagArtistEntry
+from .test_metatag_artists import TestMetatagArtists
+from .test_metatag_leaf import TestMetatagLeaf
+from .test_metatag_playlists import TestMetatagPlaylists
+from .test_metatag_sort_by_value import TestMetatagSortByValue
+from .test_metatag_title import TestMetatagTitle
+from .test_metatag_tree import TestMetatagTree
+from .test_metatags import TestMetatags
 from .test_mix_link import TestMixLink
 from .test_music_history import TestMusicHistory
 from .test_music_history_context_full_model import TestMusicHistoryContextFullModel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,16 @@ from yandex_music import (
     MadeFor,
     Major,
     MetaData,
+    Metatag,
+    MetatagAlbums,
+    MetatagArtistEntry,
+    MetatagArtists,
+    MetatagLeaf,
+    MetatagPlaylists,
+    Metatags,
+    MetatagSortByValue,
+    MetatagTitle,
+    MetatagTree,
     MixLink,
     MusicHistory,
     MusicHistoryContextFullModel,
@@ -242,6 +252,14 @@ from . import (
     TestLyricsMajor,
     TestMajor,
     TestMetaData,
+    TestMetatag,
+    TestMetatagAlbums,
+    TestMetatagArtists,
+    TestMetatagLeaf,
+    TestMetatagPlaylists,
+    TestMetatagSortByValue,
+    TestMetatagTitle,
+    TestMetatagTree,
     TestMixLink,
     TestMusicHistoryContextFullModel,
     TestMusicHistoryItem,
@@ -2139,4 +2157,112 @@ def playlist_similar_entities(similar_entity_item):
 def playlists_list(playlist):
     return PlaylistsList(
         playlists=[playlist],
+    )
+
+
+@pytest.fixture(scope='session')
+def metatag_title():
+    return MetatagTitle(title=TestMetatagTitle.title, full_title=TestMetatagTitle.full_title)
+
+
+@pytest.fixture(scope='session')
+def metatag_sort_by_value():
+    return MetatagSortByValue(
+        value=TestMetatagSortByValue.value,
+        title=TestMetatagSortByValue.title,
+        active=TestMetatagSortByValue.active,
+    )
+
+
+@pytest.fixture(scope='session')
+def metatag_leaf_nested():
+    return MetatagLeaf(tag='Спокойная музыка', title='Спокойное')
+
+
+@pytest.fixture(scope='session')
+def metatag_leaf(metatag_leaf_nested):
+    return MetatagLeaf(
+        tag=TestMetatagLeaf.tag,
+        title=TestMetatagLeaf.title,
+        leaves=[metatag_leaf_nested],
+    )
+
+
+@pytest.fixture(scope='session')
+def metatag_tree(metatag_leaf):
+    return MetatagTree(
+        title=TestMetatagTree.title,
+        navigation_id=TestMetatagTree.navigation_id,
+        leaves=[metatag_leaf],
+    )
+
+
+@pytest.fixture(scope='session')
+def metatags(metatag_tree):
+    return Metatags(trees=[metatag_tree])
+
+
+@pytest.fixture(scope='session')
+def metatag(metatag_title, artist, album, playlist, metatag_sort_by_value):
+    return Metatag(
+        id=TestMetatag.id,
+        cover_uri=TestMetatag.cover_uri,
+        color=TestMetatag.color,
+        title=metatag_title,
+        liked=TestMetatag.liked,
+        station_id=TestMetatag.station_id,
+        custom_wave_animation_url=TestMetatag.custom_wave_animation_url,
+        artists=[artist],
+        albums=[album],
+        playlists=[playlist],
+        tracks_sort_by_values=[metatag_sort_by_value],
+        albums_sort_by_values=[metatag_sort_by_value],
+        playlists_sort_by_values=[metatag_sort_by_value],
+    )
+
+
+@pytest.fixture(scope='session')
+def metatag_artist_entry(artist, track):
+    return MetatagArtistEntry(artist=artist, popular_tracks=[track])
+
+
+@pytest.fixture(scope='session')
+def metatag_artists(metatag_title, metatag_artist_entry, pager, metatag_sort_by_value):
+    return MetatagArtists(
+        id=TestMetatagArtists.id,
+        cover_uri=TestMetatagArtists.cover_uri,
+        color=TestMetatagArtists.color,
+        title=metatag_title,
+        station_id=TestMetatagArtists.station_id,
+        pager=pager,
+        artists=[metatag_artist_entry],
+        sort_by_values=[metatag_sort_by_value],
+    )
+
+
+@pytest.fixture(scope='session')
+def metatag_albums(metatag_title, album, pager, metatag_sort_by_value):
+    return MetatagAlbums(
+        id=TestMetatagAlbums.id,
+        cover_uri=TestMetatagAlbums.cover_uri,
+        color=TestMetatagAlbums.color,
+        title=metatag_title,
+        station_id=TestMetatagAlbums.station_id,
+        pager=pager,
+        albums=[album],
+        sort_by_values=[metatag_sort_by_value],
+    )
+
+
+@pytest.fixture(scope='session')
+def metatag_playlists(metatag_title, playlist, pager, metatag_sort_by_value):
+    return MetatagPlaylists(
+        id=TestMetatagPlaylists.id,
+        cover_uri=TestMetatagPlaylists.cover_uri,
+        color=TestMetatagPlaylists.color,
+        title=metatag_title,
+        station_id=TestMetatagPlaylists.station_id,
+        pager=pager,
+        playlists=[playlist],
+        sort_by_values=[metatag_sort_by_value],
     )

--- a/tests/test_metatag.py
+++ b/tests/test_metatag.py
@@ -1,0 +1,97 @@
+from yandex_music import Metatag
+
+
+class TestMetatag:
+    id = '5ddc2610e7c903105b40bc3a'
+    cover_uri = 'avatars.yandex.net/get-music-misc/2406661/meta-tag.example.cover/%%'
+    color = '#3779BC'
+    liked = False
+    station_id = 'genre:allrock'
+    custom_wave_animation_url = 'https://music-custom-wave-media.s3.yandex.net/base.json'
+
+    def test_expected_values(
+        self,
+        metatag,
+        metatag_title,
+        artist,
+        album,
+        playlist,
+        metatag_sort_by_value,
+    ):
+        assert metatag.id == self.id
+        assert metatag.cover_uri == self.cover_uri
+        assert metatag.color == self.color
+        assert metatag.title == metatag_title
+        assert metatag.liked == self.liked
+        assert metatag.station_id == self.station_id
+        assert metatag.custom_wave_animation_url == self.custom_wave_animation_url
+        assert metatag.artists == [artist]
+        assert metatag.albums == [album]
+        assert metatag.playlists == [playlist]
+        assert metatag.tracks_sort_by_values == [metatag_sort_by_value]
+        assert metatag.albums_sort_by_values == [metatag_sort_by_value]
+        assert metatag.playlists_sort_by_values == [metatag_sort_by_value]
+
+    def test_de_json_none(self, client):
+        assert Metatag.de_json({}, client) is None
+
+    def test_de_json_required(self, client):
+        json_dict = {'id': self.id}
+        metatag = Metatag.de_json(json_dict, client)
+
+        assert metatag.id == self.id
+        assert metatag.title is None
+        assert metatag.artists == []
+        assert metatag.albums == []
+        assert metatag.playlists == []
+
+    def test_de_json_all(
+        self,
+        client,
+        metatag_title,
+        artist,
+        album,
+        playlist,
+        metatag_sort_by_value,
+    ):
+        json_dict = {
+            'id': self.id,
+            'coverUri': self.cover_uri,
+            'color': self.color,
+            'title': metatag_title.to_dict(),
+            'liked': self.liked,
+            'stationId': self.station_id,
+            'customWaveAnimationUrl': self.custom_wave_animation_url,
+            'artists': [artist.to_dict()],
+            'albums': [album.to_dict()],
+            'playlists': [playlist.to_dict()],
+            'tracksSortByValues': [metatag_sort_by_value.to_dict()],
+            'albumsSortByValues': [metatag_sort_by_value.to_dict()],
+            'playlistsSortByValues': [metatag_sort_by_value.to_dict()],
+        }
+        metatag = Metatag.de_json(json_dict, client)
+
+        assert metatag.id == self.id
+        assert metatag.cover_uri == self.cover_uri
+        assert metatag.color == self.color
+        assert metatag.title == metatag_title
+        assert metatag.liked == self.liked
+        assert metatag.station_id == self.station_id
+        assert metatag.custom_wave_animation_url == self.custom_wave_animation_url
+        assert metatag.artists == [artist]
+        assert metatag.albums == [album]
+        assert metatag.playlists == [playlist]
+        assert metatag.tracks_sort_by_values == [metatag_sort_by_value]
+        assert metatag.albums_sort_by_values == [metatag_sort_by_value]
+        assert metatag.playlists_sort_by_values == [metatag_sort_by_value]
+
+    def test_equality(self):
+        a = Metatag(id=self.id)
+        b = Metatag(id='other')
+        c = Metatag(id=self.id)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_metatag_albums.py
+++ b/tests/test_metatag_albums.py
@@ -1,0 +1,98 @@
+import pytest
+
+from yandex_music import MetatagAlbums
+
+
+@pytest.fixture(scope='class')
+def metatag_albums_factory(album, pager, metatag_title, metatag_sort_by_value):
+    def factory(**overrides):
+        defaults = {
+            'id': TestMetatagAlbums.id,
+            'cover_uri': TestMetatagAlbums.cover_uri,
+            'color': TestMetatagAlbums.color,
+            'title': metatag_title,
+            'station_id': TestMetatagAlbums.station_id,
+            'pager': pager,
+            'albums': [album],
+            'sort_by_values': [metatag_sort_by_value],
+        }
+        defaults.update(overrides)
+        return MetatagAlbums(**defaults)
+
+    return factory
+
+
+class TestMetatagAlbums:
+    id = '5ddc2610e7c903105b40bc3a'
+    cover_uri = 'avatars.yandex.net/get-music-misc/2406661/meta-tag.example.cover/%%'
+    color = '#3779BC'
+    station_id = 'genre:allrock'
+
+    def test_expected_values(
+        self,
+        metatag_albums,
+        album,
+        pager,
+        metatag_title,
+        metatag_sort_by_value,
+    ):
+        assert metatag_albums.id == self.id
+        assert metatag_albums.cover_uri == self.cover_uri
+        assert metatag_albums.color == self.color
+        assert metatag_albums.title == metatag_title
+        assert metatag_albums.station_id == self.station_id
+        assert metatag_albums.pager == pager
+        assert metatag_albums.albums == [album]
+        assert metatag_albums.sort_by_values == [metatag_sort_by_value]
+
+    def test_de_json_none(self, client):
+        assert MetatagAlbums.de_json({}, client) is None
+
+    def test_de_json_all(
+        self,
+        client,
+        album,
+        pager,
+        metatag_title,
+        metatag_sort_by_value,
+    ):
+        json_dict = {
+            'id': self.id,
+            'coverUri': self.cover_uri,
+            'color': self.color,
+            'title': metatag_title.to_dict(),
+            'stationId': self.station_id,
+            'pager': pager.to_dict(),
+            'albums': [album.to_dict()],
+            'sortByValues': [metatag_sort_by_value.to_dict()],
+        }
+        metatag_albums = MetatagAlbums.de_json(json_dict, client)
+
+        assert metatag_albums.id == self.id
+        assert metatag_albums.cover_uri == self.cover_uri
+        assert metatag_albums.color == self.color
+        assert metatag_albums.title == metatag_title
+        assert metatag_albums.station_id == self.station_id
+        assert metatag_albums.pager == pager
+        assert metatag_albums.albums == [album]
+        assert metatag_albums.sort_by_values == [metatag_sort_by_value]
+
+    def test_equality(self, metatag_albums_factory):
+        a = metatag_albums_factory()
+        b = metatag_albums_factory(id='other')
+        c = metatag_albums_factory()
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c
+
+    def test_len(self, metatag_albums):
+        assert len(metatag_albums) == len(metatag_albums.albums)
+
+    def test_getitem(self, metatag_albums):
+        assert metatag_albums[0] == metatag_albums.albums[0]
+
+    def test_iter(self, metatag_albums):
+        assert list(metatag_albums) == metatag_albums.albums

--- a/tests/test_metatag_artist_entry.py
+++ b/tests/test_metatag_artist_entry.py
@@ -1,0 +1,38 @@
+from yandex_music import MetatagArtistEntry
+
+
+class TestMetatagArtistEntry:
+    def test_expected_values(self, metatag_artist_entry, artist, track):
+        assert metatag_artist_entry.artist == artist
+        assert metatag_artist_entry.popular_tracks == [track]
+
+    def test_de_json_none(self, client):
+        assert MetatagArtistEntry.de_json({}, client) is None
+
+    def test_de_json_required(self, client, artist):
+        json_dict = {'artist': artist.to_dict()}
+        metatag_artist_entry = MetatagArtistEntry.de_json(json_dict, client)
+
+        assert metatag_artist_entry.artist == artist
+        assert metatag_artist_entry.popular_tracks == []
+
+    def test_de_json_all(self, client, artist, track):
+        json_dict = {
+            'artist': artist.to_dict(),
+            'popularTracks': [track.to_dict()],
+        }
+        metatag_artist_entry = MetatagArtistEntry.de_json(json_dict, client)
+
+        assert metatag_artist_entry.artist == artist
+        assert metatag_artist_entry.popular_tracks == [track]
+
+    def test_equality(self, artist, track):
+        a = MetatagArtistEntry(artist=artist, popular_tracks=[track])
+        b = MetatagArtistEntry(artist=None, popular_tracks=[track])
+        c = MetatagArtistEntry(artist=artist, popular_tracks=[track])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_metatag_artists.py
+++ b/tests/test_metatag_artists.py
@@ -1,0 +1,98 @@
+import pytest
+
+from yandex_music import MetatagArtists
+
+
+@pytest.fixture(scope='class')
+def metatag_artists_factory(metatag_artist_entry, pager, metatag_title, metatag_sort_by_value):
+    def factory(**overrides):
+        defaults = {
+            'id': TestMetatagArtists.id,
+            'cover_uri': TestMetatagArtists.cover_uri,
+            'color': TestMetatagArtists.color,
+            'title': metatag_title,
+            'station_id': TestMetatagArtists.station_id,
+            'pager': pager,
+            'artists': [metatag_artist_entry],
+            'sort_by_values': [metatag_sort_by_value],
+        }
+        defaults.update(overrides)
+        return MetatagArtists(**defaults)
+
+    return factory
+
+
+class TestMetatagArtists:
+    id = '5ddc2610e7c903105b40bc3a'
+    cover_uri = 'avatars.yandex.net/get-music-misc/2406661/meta-tag.example.cover/%%'
+    color = '#3779BC'
+    station_id = 'genre:allrock'
+
+    def test_expected_values(
+        self,
+        metatag_artists,
+        metatag_artist_entry,
+        pager,
+        metatag_title,
+        metatag_sort_by_value,
+    ):
+        assert metatag_artists.id == self.id
+        assert metatag_artists.cover_uri == self.cover_uri
+        assert metatag_artists.color == self.color
+        assert metatag_artists.title == metatag_title
+        assert metatag_artists.station_id == self.station_id
+        assert metatag_artists.pager == pager
+        assert metatag_artists.artists == [metatag_artist_entry]
+        assert metatag_artists.sort_by_values == [metatag_sort_by_value]
+
+    def test_de_json_none(self, client):
+        assert MetatagArtists.de_json({}, client) is None
+
+    def test_de_json_all(
+        self,
+        client,
+        metatag_artist_entry,
+        pager,
+        metatag_title,
+        metatag_sort_by_value,
+    ):
+        json_dict = {
+            'id': self.id,
+            'coverUri': self.cover_uri,
+            'color': self.color,
+            'title': metatag_title.to_dict(),
+            'stationId': self.station_id,
+            'pager': pager.to_dict(),
+            'artists': [metatag_artist_entry.to_dict()],
+            'sortByValues': [metatag_sort_by_value.to_dict()],
+        }
+        metatag_artists = MetatagArtists.de_json(json_dict, client)
+
+        assert metatag_artists.id == self.id
+        assert metatag_artists.cover_uri == self.cover_uri
+        assert metatag_artists.color == self.color
+        assert metatag_artists.title == metatag_title
+        assert metatag_artists.station_id == self.station_id
+        assert metatag_artists.pager == pager
+        assert metatag_artists.artists == [metatag_artist_entry]
+        assert metatag_artists.sort_by_values == [metatag_sort_by_value]
+
+    def test_equality(self, metatag_artists_factory):
+        a = metatag_artists_factory()
+        b = metatag_artists_factory(id='other')
+        c = metatag_artists_factory()
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c
+
+    def test_len(self, metatag_artists):
+        assert len(metatag_artists) == len(metatag_artists.artists)
+
+    def test_getitem(self, metatag_artists):
+        assert metatag_artists[0] == metatag_artists.artists[0]
+
+    def test_iter(self, metatag_artists):
+        assert list(metatag_artists) == metatag_artists.artists

--- a/tests/test_metatag_leaf.py
+++ b/tests/test_metatag_leaf.py
@@ -1,0 +1,45 @@
+from yandex_music import MetatagLeaf
+
+
+class TestMetatagLeaf:
+    tag = 'Весенняя музыка'
+    title = 'Весеннее'
+
+    def test_expected_values(self, metatag_leaf, metatag_leaf_nested):
+        assert metatag_leaf.tag == self.tag
+        assert metatag_leaf.title == self.title
+        assert metatag_leaf.leaves == [metatag_leaf_nested]
+
+    def test_de_json_none(self, client):
+        assert MetatagLeaf.de_json({}, client) is None
+
+    def test_de_json_required(self, client):
+        json_dict = {'tag': self.tag, 'title': self.title}
+        metatag_leaf = MetatagLeaf.de_json(json_dict, client)
+
+        assert metatag_leaf.tag == self.tag
+        assert metatag_leaf.title == self.title
+        assert metatag_leaf.leaves == []
+
+    def test_de_json_all(self, client, metatag_leaf_nested):
+        json_dict = {
+            'tag': self.tag,
+            'title': self.title,
+            'leaves': [metatag_leaf_nested.to_dict()],
+        }
+        metatag_leaf = MetatagLeaf.de_json(json_dict, client)
+
+        assert metatag_leaf.tag == self.tag
+        assert metatag_leaf.title == self.title
+        assert metatag_leaf.leaves == [metatag_leaf_nested]
+
+    def test_equality(self, metatag_leaf_nested):
+        a = MetatagLeaf(tag=self.tag, title=self.title, leaves=[metatag_leaf_nested])
+        b = MetatagLeaf(tag='other', title=self.title, leaves=[metatag_leaf_nested])
+        c = MetatagLeaf(tag=self.tag, title=self.title, leaves=[metatag_leaf_nested])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_metatag_playlists.py
+++ b/tests/test_metatag_playlists.py
@@ -1,0 +1,98 @@
+import pytest
+
+from yandex_music import MetatagPlaylists
+
+
+@pytest.fixture(scope='class')
+def metatag_playlists_factory(playlist, pager, metatag_title, metatag_sort_by_value):
+    def factory(**overrides):
+        defaults = {
+            'id': TestMetatagPlaylists.id,
+            'cover_uri': TestMetatagPlaylists.cover_uri,
+            'color': TestMetatagPlaylists.color,
+            'title': metatag_title,
+            'station_id': TestMetatagPlaylists.station_id,
+            'pager': pager,
+            'playlists': [playlist],
+            'sort_by_values': [metatag_sort_by_value],
+        }
+        defaults.update(overrides)
+        return MetatagPlaylists(**defaults)
+
+    return factory
+
+
+class TestMetatagPlaylists:
+    id = '5ddc2610e7c903105b40bc3a'
+    cover_uri = 'avatars.yandex.net/get-music-misc/2406661/meta-tag.example.cover/%%'
+    color = '#3779BC'
+    station_id = 'genre:allrock'
+
+    def test_expected_values(
+        self,
+        metatag_playlists,
+        playlist,
+        pager,
+        metatag_title,
+        metatag_sort_by_value,
+    ):
+        assert metatag_playlists.id == self.id
+        assert metatag_playlists.cover_uri == self.cover_uri
+        assert metatag_playlists.color == self.color
+        assert metatag_playlists.title == metatag_title
+        assert metatag_playlists.station_id == self.station_id
+        assert metatag_playlists.pager == pager
+        assert metatag_playlists.playlists == [playlist]
+        assert metatag_playlists.sort_by_values == [metatag_sort_by_value]
+
+    def test_de_json_none(self, client):
+        assert MetatagPlaylists.de_json({}, client) is None
+
+    def test_de_json_all(
+        self,
+        client,
+        playlist,
+        pager,
+        metatag_title,
+        metatag_sort_by_value,
+    ):
+        json_dict = {
+            'id': self.id,
+            'coverUri': self.cover_uri,
+            'color': self.color,
+            'title': metatag_title.to_dict(),
+            'stationId': self.station_id,
+            'pager': pager.to_dict(),
+            'playlists': [playlist.to_dict()],
+            'sortByValues': [metatag_sort_by_value.to_dict()],
+        }
+        metatag_playlists = MetatagPlaylists.de_json(json_dict, client)
+
+        assert metatag_playlists.id == self.id
+        assert metatag_playlists.cover_uri == self.cover_uri
+        assert metatag_playlists.color == self.color
+        assert metatag_playlists.title == metatag_title
+        assert metatag_playlists.station_id == self.station_id
+        assert metatag_playlists.pager == pager
+        assert metatag_playlists.playlists == [playlist]
+        assert metatag_playlists.sort_by_values == [metatag_sort_by_value]
+
+    def test_equality(self, metatag_playlists_factory):
+        a = metatag_playlists_factory()
+        b = metatag_playlists_factory(id='other')
+        c = metatag_playlists_factory()
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c
+
+    def test_len(self, metatag_playlists):
+        assert len(metatag_playlists) == len(metatag_playlists.playlists)
+
+    def test_getitem(self, metatag_playlists):
+        assert metatag_playlists[0] == metatag_playlists.playlists[0]
+
+    def test_iter(self, metatag_playlists):
+        assert list(metatag_playlists) == metatag_playlists.playlists

--- a/tests/test_metatag_sort_by_value.py
+++ b/tests/test_metatag_sort_by_value.py
@@ -1,0 +1,34 @@
+from yandex_music import MetatagSortByValue
+
+
+class TestMetatagSortByValue:
+    value = 'popular'
+    title = 'Сначала популярные'
+    active = True
+
+    def test_expected_values(self, metatag_sort_by_value):
+        assert metatag_sort_by_value.value == self.value
+        assert metatag_sort_by_value.title == self.title
+        assert metatag_sort_by_value.active == self.active
+
+    def test_de_json_none(self, client):
+        assert MetatagSortByValue.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {'value': self.value, 'title': self.title, 'active': self.active}
+        metatag_sort_by_value = MetatagSortByValue.de_json(json_dict, client)
+
+        assert metatag_sort_by_value.value == self.value
+        assert metatag_sort_by_value.title == self.title
+        assert metatag_sort_by_value.active == self.active
+
+    def test_equality(self):
+        a = MetatagSortByValue(value=self.value, title=self.title, active=self.active)
+        b = MetatagSortByValue(value='new', title=self.title, active=self.active)
+        c = MetatagSortByValue(value=self.value, title=self.title, active=self.active)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_metatag_title.py
+++ b/tests/test_metatag_title.py
@@ -1,0 +1,31 @@
+from yandex_music import MetatagTitle
+
+
+class TestMetatagTitle:
+    title = 'Рок'
+    full_title = 'Рок-музыка'
+
+    def test_expected_values(self, metatag_title):
+        assert metatag_title.title == self.title
+        assert metatag_title.full_title == self.full_title
+
+    def test_de_json_none(self, client):
+        assert MetatagTitle.de_json({}, client) is None
+
+    def test_de_json_all(self, client):
+        json_dict = {'title': self.title, 'fullTitle': self.full_title}
+        metatag_title = MetatagTitle.de_json(json_dict, client)
+
+        assert metatag_title.title == self.title
+        assert metatag_title.full_title == self.full_title
+
+    def test_equality(self):
+        a = MetatagTitle(title=self.title, full_title=self.full_title)
+        b = MetatagTitle(title='other', full_title=self.full_title)
+        c = MetatagTitle(title=self.title, full_title=self.full_title)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_metatag_tree.py
+++ b/tests/test_metatag_tree.py
@@ -1,0 +1,45 @@
+from yandex_music import MetatagTree
+
+
+class TestMetatagTree:
+    title = 'Настроения'
+    navigation_id = 'moods'
+
+    def test_expected_values(self, metatag_tree, metatag_leaf):
+        assert metatag_tree.title == self.title
+        assert metatag_tree.navigation_id == self.navigation_id
+        assert metatag_tree.leaves == [metatag_leaf]
+
+    def test_de_json_none(self, client):
+        assert MetatagTree.de_json({}, client) is None
+
+    def test_de_json_required(self, client):
+        json_dict = {'title': self.title, 'navigationId': self.navigation_id}
+        metatag_tree = MetatagTree.de_json(json_dict, client)
+
+        assert metatag_tree.title == self.title
+        assert metatag_tree.navigation_id == self.navigation_id
+        assert metatag_tree.leaves == []
+
+    def test_de_json_all(self, client, metatag_leaf):
+        json_dict = {
+            'title': self.title,
+            'navigationId': self.navigation_id,
+            'leaves': [metatag_leaf.to_dict()],
+        }
+        metatag_tree = MetatagTree.de_json(json_dict, client)
+
+        assert metatag_tree.title == self.title
+        assert metatag_tree.navigation_id == self.navigation_id
+        assert metatag_tree.leaves == [metatag_leaf]
+
+    def test_equality(self, metatag_leaf):
+        a = MetatagTree(title=self.title, navigation_id=self.navigation_id, leaves=[metatag_leaf])
+        b = MetatagTree(title=self.title, navigation_id='other', leaves=[metatag_leaf])
+        c = MetatagTree(title=self.title, navigation_id=self.navigation_id, leaves=[metatag_leaf])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_metatags.py
+++ b/tests/test_metatags.py
@@ -1,0 +1,35 @@
+from yandex_music import Metatags
+
+
+class TestMetatags:
+    def test_expected_values(self, metatags, metatag_tree):
+        assert metatags.trees == [metatag_tree]
+
+    def test_de_json_none(self, client):
+        assert Metatags.de_json({}, client) is None
+
+    def test_de_json_all(self, client, metatag_tree):
+        json_dict = {'trees': [metatag_tree.to_dict()]}
+        metatags = Metatags.de_json(json_dict, client)
+
+        assert metatags.trees == [metatag_tree]
+
+    def test_equality(self, metatag_tree):
+        a = Metatags(trees=[metatag_tree])
+        b = Metatags(trees=[])
+        c = Metatags(trees=[metatag_tree])
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c
+
+    def test_len(self, metatags):
+        assert len(metatags) == len(metatags.trees)
+
+    def test_getitem(self, metatags):
+        assert metatags[0] == metatags.trees[0]
+
+    def test_iter(self, metatags):
+        assert list(metatags) == metatags.trees

--- a/yandex_music/__init__.py
+++ b/yandex_music/__init__.py
@@ -88,6 +88,17 @@ from .label.label import Label
 from .label.label_albums import LabelAlbums
 from .label.label_artists import LabelArtists
 
+from .metatag.metatag_title import MetatagTitle
+from .metatag.metatag_sort_by_value import MetatagSortByValue
+from .metatag.metatag_leaf import MetatagLeaf
+from .metatag.metatag_tree import MetatagTree
+from .metatag.metatags import Metatags
+from .metatag.metatag import Metatag
+from .metatag.metatag_artist_entry import MetatagArtistEntry
+from .metatag.metatag_artists import MetatagArtists
+from .metatag.metatag_albums import MetatagAlbums
+from .metatag.metatag_playlists import MetatagPlaylists
+
 from .playlist.case_forms import CaseForms
 from .playlist.made_for import MadeFor
 from .playlist.user import User
@@ -333,6 +344,16 @@ __all__ = [
     'Major',
     'MapTypeToDeJson',
     'MetaData',
+    'Metatag',
+    'MetatagAlbums',
+    'MetatagArtistEntry',
+    'MetatagArtists',
+    'MetatagLeaf',
+    'MetatagPlaylists',
+    'MetatagSortByValue',
+    'MetatagTitle',
+    'MetatagTree',
+    'Metatags',
     'MixLink',
     'MusicHistory',
     'MusicHistoryContextFullModel',

--- a/yandex_music/_client/metatags.py
+++ b/yandex_music/_client/metatags.py
@@ -1,0 +1,259 @@
+#################################################################################################
+# THIS IS AUTO GENERATED COPY OF yandex_music/_client_async/metatags.py. DON'T EDIT IT BY HANDS #
+#################################################################################################
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from yandex_music import (
+    Metatag,
+    MetatagAlbums,
+    MetatagArtists,
+    MetatagPlaylists,
+    Metatags,
+)
+from yandex_music._client import log
+from yandex_music._client_base import ClientBase
+
+if TYPE_CHECKING:
+    from yandex_music.utils.request import Request
+
+
+class MetatagsMixin(ClientBase):
+    """Метатеги.
+
+    Миксин для методов, связанных с метатегами (подборки по настроениям, занятиям, жанрам и эпохам).
+    """
+
+    _request: 'Request'
+
+    @log
+    def metatags(self, *args: Any, **kwargs: Any) -> Optional[Metatags]:
+        """Получение дерева метатегов.
+
+        Args:
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Metatags` | :obj:`None`: Дерево метатегов или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/landing3/metatags'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return Metatags.de_json(result, self)
+
+    @log
+    def metatag(
+        self,
+        metatag_id: str,
+        tracks_count: Optional[int] = None,
+        artists_count: Optional[int] = None,
+        composers_count: Optional[int] = None,
+        albums_count: Optional[int] = None,
+        promotions_count: Optional[int] = None,
+        features_count: Optional[int] = None,
+        playlists_count: Optional[int] = None,
+        concerts_count: Optional[int] = None,
+        tracks_sort_by: Optional[str] = None,
+        albums_sort_by: Optional[str] = None,
+        with_likes_count: Optional[bool] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[Metatag]:
+        """Получение информации о метатеге.
+
+        Note:
+            Известные значения для `tracks_sort_by` и `albums_sort_by`: `popular`, `new`.
+
+            Поля `tracks`, `composers`, `promotions`, `features` и `concerts` в модели
+            :obj:`yandex_music.Metatag` не представлены, так как во всех опробованных
+            метатегах возвращали пустой список.
+
+        Args:
+            metatag_id (:obj:`str`): Идентификатор метатега.
+            tracks_count (:obj:`int`, optional): Количество треков в ответе.
+            artists_count (:obj:`int`, optional): Количество артистов в ответе.
+            composers_count (:obj:`int`, optional): Количество композиторов в ответе.
+            albums_count (:obj:`int`, optional): Количество альбомов в ответе.
+            promotions_count (:obj:`int`, optional): Количество промоакций в ответе.
+            features_count (:obj:`int`, optional): Количество фич в ответе.
+            playlists_count (:obj:`int`, optional): Количество плейлистов в ответе.
+            concerts_count (:obj:`int`, optional): Количество концертов в ответе.
+            tracks_sort_by (:obj:`str`, optional): Параметр сортировки треков.
+            albums_sort_by (:obj:`str`, optional): Параметр сортировки альбомов.
+            with_likes_count (:obj:`bool`, optional): Возвращать ли количество лайков.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Metatag` | :obj:`None`: Метатег или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/metatags/{metatag_id}'
+
+        raw_params = {
+            'tracksCount': tracks_count,
+            'artistsCount': artists_count,
+            'composersCount': composers_count,
+            'albumsCount': albums_count,
+            'promotionsCount': promotions_count,
+            'featuresCount': features_count,
+            'playlistsCount': playlists_count,
+            'concertsCount': concerts_count,
+            'tracksSortBy': tracks_sort_by,
+            'albumsSortBy': albums_sort_by,
+            'withLikesCount': with_likes_count,
+        }
+        params = {k: v for k, v in raw_params.items() if v is not None}
+
+        result = self._request.get(url, params, *args, **kwargs)
+
+        return Metatag.de_json(result, self)
+
+    @log
+    def metatag_albums(
+        self,
+        metatag_id: str,
+        period: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 25,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[MetatagAlbums]:
+        """Получение альбомов метатега.
+
+        Note:
+            Известные значения для `sort_by`: `popular`, `new`.
+
+        Args:
+            metatag_id (:obj:`str`): Идентификатор метатега.
+            period (:obj:`str`, optional): Период выборки.
+            sort_by (:obj:`str`, optional): Параметр сортировки.
+            offset (:obj:`int`, optional): Смещение от начала списка.
+            limit (:obj:`int`, optional): Количество альбомов на странице.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.MetatagAlbums` | :obj:`None`: Страница списка альбомов метатега или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/metatags/{metatag_id}/albums'
+
+        params: dict = {'offset': offset, 'limit': limit}
+        if period is not None:
+            params['period'] = period
+        if sort_by is not None:
+            params['sortBy'] = sort_by
+
+        result = self._request.get(url, params, *args, **kwargs)
+
+        return MetatagAlbums.de_json(result, self)
+
+    @log
+    def metatag_artists(
+        self,
+        metatag_id: str,
+        period: str = 'week',
+        sort_by: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 25,
+        tracks_per_artist: Optional[int] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[MetatagArtists]:
+        """Получение артистов метатега.
+
+        Note:
+            Параметр `period` обязателен (без него API возвращает ошибку валидации).
+            Известные значения для `period`: `week`, `month`, `day`.
+            Известные значения для `sort_by`: `popular`.
+
+        Args:
+            metatag_id (:obj:`str`): Идентификатор метатега.
+            period (:obj:`str`, optional): Период выборки.
+            sort_by (:obj:`str`, optional): Параметр сортировки.
+            offset (:obj:`int`, optional): Смещение от начала списка.
+            limit (:obj:`int`, optional): Количество артистов на странице.
+            tracks_per_artist (:obj:`int`, optional): Количество популярных треков на артиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.MetatagArtists` | :obj:`None`: Страница списка артистов метатега или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/metatags/{metatag_id}/artists'
+
+        params: dict = {'period': period, 'offset': offset, 'limit': limit}
+        if sort_by is not None:
+            params['sortBy'] = sort_by
+        if tracks_per_artist is not None:
+            params['tracksPerArtist'] = tracks_per_artist
+
+        result = self._request.get(url, params, *args, **kwargs)
+
+        return MetatagArtists.de_json(result, self)
+
+    @log
+    def metatag_playlists(
+        self,
+        metatag_id: str,
+        sort_by: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 25,
+        with_likes_count: Optional[bool] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[MetatagPlaylists]:
+        """Получение плейлистов метатега.
+
+        Note:
+            Известные значения для `sort_by`: `popular`, `new`.
+
+        Args:
+            metatag_id (:obj:`str`): Идентификатор метатега.
+            sort_by (:obj:`str`, optional): Параметр сортировки.
+            offset (:obj:`int`, optional): Смещение от начала списка.
+            limit (:obj:`int`, optional): Количество плейлистов на странице.
+            with_likes_count (:obj:`bool`, optional): Возвращать ли количество лайков.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.MetatagPlaylists` | :obj:`None`: Страница списка плейлистов метатега или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/metatags/{metatag_id}/playlists'
+
+        params: dict = {'offset': offset, 'limit': limit}
+        if sort_by is not None:
+            params['sortBy'] = sort_by
+        if with_likes_count is not None:
+            params['withLikesCount'] = with_likes_count
+
+        result = self._request.get(url, params, *args, **kwargs)
+
+        return MetatagPlaylists.de_json(result, self)
+
+    # camelCase псевдонимы
+
+    #: Псевдоним для :attr:`metatag_albums`
+    metatagAlbums = metatag_albums
+    #: Псевдоним для :attr:`metatag_artists`
+    metatagArtists = metatag_artists
+    #: Псевдоним для :attr:`metatag_playlists`
+    metatagPlaylists = metatag_playlists

--- a/yandex_music/_client_async/metatags.py
+++ b/yandex_music/_client_async/metatags.py
@@ -1,0 +1,255 @@
+from typing import TYPE_CHECKING, Any, Optional
+
+from yandex_music import (
+    Metatag,
+    MetatagAlbums,
+    MetatagArtists,
+    MetatagPlaylists,
+    Metatags,
+)
+from yandex_music._client_async import log
+from yandex_music._client_base import ClientBase
+
+if TYPE_CHECKING:
+    from yandex_music.utils.request_async import Request
+
+
+class MetatagsMixin(ClientBase):
+    """Метатеги.
+
+    Миксин для методов, связанных с метатегами (подборки по настроениям, занятиям, жанрам и эпохам).
+    """
+
+    _request: 'Request'
+
+    @log
+    async def metatags(self, *args: Any, **kwargs: Any) -> Optional[Metatags]:
+        """Получение дерева метатегов.
+
+        Args:
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Metatags` | :obj:`None`: Дерево метатегов или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/landing3/metatags'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return Metatags.de_json(result, self)
+
+    @log
+    async def metatag(
+        self,
+        metatag_id: str,
+        tracks_count: Optional[int] = None,
+        artists_count: Optional[int] = None,
+        composers_count: Optional[int] = None,
+        albums_count: Optional[int] = None,
+        promotions_count: Optional[int] = None,
+        features_count: Optional[int] = None,
+        playlists_count: Optional[int] = None,
+        concerts_count: Optional[int] = None,
+        tracks_sort_by: Optional[str] = None,
+        albums_sort_by: Optional[str] = None,
+        with_likes_count: Optional[bool] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[Metatag]:
+        """Получение информации о метатеге.
+
+        Note:
+            Известные значения для `tracks_sort_by` и `albums_sort_by`: `popular`, `new`.
+
+            Поля `tracks`, `composers`, `promotions`, `features` и `concerts` в модели
+            :obj:`yandex_music.Metatag` не представлены, так как во всех опробованных
+            метатегах возвращали пустой список.
+
+        Args:
+            metatag_id (:obj:`str`): Идентификатор метатега.
+            tracks_count (:obj:`int`, optional): Количество треков в ответе.
+            artists_count (:obj:`int`, optional): Количество артистов в ответе.
+            composers_count (:obj:`int`, optional): Количество композиторов в ответе.
+            albums_count (:obj:`int`, optional): Количество альбомов в ответе.
+            promotions_count (:obj:`int`, optional): Количество промоакций в ответе.
+            features_count (:obj:`int`, optional): Количество фич в ответе.
+            playlists_count (:obj:`int`, optional): Количество плейлистов в ответе.
+            concerts_count (:obj:`int`, optional): Количество концертов в ответе.
+            tracks_sort_by (:obj:`str`, optional): Параметр сортировки треков.
+            albums_sort_by (:obj:`str`, optional): Параметр сортировки альбомов.
+            with_likes_count (:obj:`bool`, optional): Возвращать ли количество лайков.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.Metatag` | :obj:`None`: Метатег или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/metatags/{metatag_id}'
+
+        raw_params = {
+            'tracksCount': tracks_count,
+            'artistsCount': artists_count,
+            'composersCount': composers_count,
+            'albumsCount': albums_count,
+            'promotionsCount': promotions_count,
+            'featuresCount': features_count,
+            'playlistsCount': playlists_count,
+            'concertsCount': concerts_count,
+            'tracksSortBy': tracks_sort_by,
+            'albumsSortBy': albums_sort_by,
+            'withLikesCount': with_likes_count,
+        }
+        params = {k: v for k, v in raw_params.items() if v is not None}
+
+        result = await self._request.get(url, params, *args, **kwargs)
+
+        return Metatag.de_json(result, self)
+
+    @log
+    async def metatag_albums(
+        self,
+        metatag_id: str,
+        period: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 25,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[MetatagAlbums]:
+        """Получение альбомов метатега.
+
+        Note:
+            Известные значения для `sort_by`: `popular`, `new`.
+
+        Args:
+            metatag_id (:obj:`str`): Идентификатор метатега.
+            period (:obj:`str`, optional): Период выборки.
+            sort_by (:obj:`str`, optional): Параметр сортировки.
+            offset (:obj:`int`, optional): Смещение от начала списка.
+            limit (:obj:`int`, optional): Количество альбомов на странице.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.MetatagAlbums` | :obj:`None`: Страница списка альбомов метатега или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/metatags/{metatag_id}/albums'
+
+        params: dict = {'offset': offset, 'limit': limit}
+        if period is not None:
+            params['period'] = period
+        if sort_by is not None:
+            params['sortBy'] = sort_by
+
+        result = await self._request.get(url, params, *args, **kwargs)
+
+        return MetatagAlbums.de_json(result, self)
+
+    @log
+    async def metatag_artists(
+        self,
+        metatag_id: str,
+        period: str = 'week',
+        sort_by: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 25,
+        tracks_per_artist: Optional[int] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[MetatagArtists]:
+        """Получение артистов метатега.
+
+        Note:
+            Параметр `period` обязателен (без него API возвращает ошибку валидации).
+            Известные значения для `period`: `week`, `month`, `day`.
+            Известные значения для `sort_by`: `popular`.
+
+        Args:
+            metatag_id (:obj:`str`): Идентификатор метатега.
+            period (:obj:`str`, optional): Период выборки.
+            sort_by (:obj:`str`, optional): Параметр сортировки.
+            offset (:obj:`int`, optional): Смещение от начала списка.
+            limit (:obj:`int`, optional): Количество артистов на странице.
+            tracks_per_artist (:obj:`int`, optional): Количество популярных треков на артиста.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.MetatagArtists` | :obj:`None`: Страница списка артистов метатега или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/metatags/{metatag_id}/artists'
+
+        params: dict = {'period': period, 'offset': offset, 'limit': limit}
+        if sort_by is not None:
+            params['sortBy'] = sort_by
+        if tracks_per_artist is not None:
+            params['tracksPerArtist'] = tracks_per_artist
+
+        result = await self._request.get(url, params, *args, **kwargs)
+
+        return MetatagArtists.de_json(result, self)
+
+    @log
+    async def metatag_playlists(
+        self,
+        metatag_id: str,
+        sort_by: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 25,
+        with_likes_count: Optional[bool] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Optional[MetatagPlaylists]:
+        """Получение плейлистов метатега.
+
+        Note:
+            Известные значения для `sort_by`: `popular`, `new`.
+
+        Args:
+            metatag_id (:obj:`str`): Идентификатор метатега.
+            sort_by (:obj:`str`, optional): Параметр сортировки.
+            offset (:obj:`int`, optional): Смещение от начала списка.
+            limit (:obj:`int`, optional): Количество плейлистов на странице.
+            with_likes_count (:obj:`bool`, optional): Возвращать ли количество лайков.
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.MetatagPlaylists` | :obj:`None`: Страница списка плейлистов метатега или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/metatags/{metatag_id}/playlists'
+
+        params: dict = {'offset': offset, 'limit': limit}
+        if sort_by is not None:
+            params['sortBy'] = sort_by
+        if with_likes_count is not None:
+            params['withLikesCount'] = with_likes_count
+
+        result = await self._request.get(url, params, *args, **kwargs)
+
+        return MetatagPlaylists.de_json(result, self)
+
+    # camelCase псевдонимы
+
+    #: Псевдоним для :attr:`metatag_albums`
+    metatagAlbums = metatag_albums
+    #: Псевдоним для :attr:`metatag_artists`
+    metatagArtists = metatag_artists
+    #: Псевдоним для :attr:`metatag_playlists`
+    metatagPlaylists = metatag_playlists

--- a/yandex_music/client.py
+++ b/yandex_music/client.py
@@ -17,6 +17,7 @@ from yandex_music._client.disclaimers import DisclaimersMixin
 from yandex_music._client.labels import LabelsMixin
 from yandex_music._client.landing import LandingMixin
 from yandex_music._client.likes import LikesMixin
+from yandex_music._client.metatags import MetatagsMixin
 from yandex_music._client.music_history import MusicHistoryMixin
 from yandex_music._client.pins import PinsMixin
 from yandex_music._client.playlists import PlaylistsMixin
@@ -45,6 +46,7 @@ class Client(
     RadioMixin,
     ArtistsMixin,
     LikesMixin,
+    MetatagsMixin,
     MusicHistoryMixin,
     PinsMixin,
     PresavesMixin,

--- a/yandex_music/client_async.py
+++ b/yandex_music/client_async.py
@@ -13,6 +13,7 @@ from yandex_music._client_async.disclaimers import DisclaimersMixin
 from yandex_music._client_async.labels import LabelsMixin
 from yandex_music._client_async.landing import LandingMixin
 from yandex_music._client_async.likes import LikesMixin
+from yandex_music._client_async.metatags import MetatagsMixin
 from yandex_music._client_async.music_history import MusicHistoryMixin
 from yandex_music._client_async.pins import PinsMixin
 from yandex_music._client_async.playlists import PlaylistsMixin
@@ -41,6 +42,7 @@ class ClientAsync(
     RadioMixin,
     ArtistsMixin,
     LikesMixin,
+    MetatagsMixin,
     MusicHistoryMixin,
     PinsMixin,
     PresavesMixin,

--- a/yandex_music/metatag/metatag.py
+++ b/yandex_music/metatag/metatag.py
@@ -1,0 +1,99 @@
+from dataclasses import field
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import (
+        Album,
+        Artist,
+        ClientType,
+        JSONType,
+        MetatagSortByValue,
+        MetatagTitle,
+        Playlist,
+    )
+
+
+@model
+class Metatag(YandexMusicModel):
+    """Класс, представляющий метатег.
+
+    Note:
+        Метатег объединяет артистов, альбомы и плейлисты по настроению, жанру, эпохе
+        или занятию. Поле :attr:`station_id` позволяет запустить соответствующую радиостанцию.
+
+    Warning:
+        API также возвращает поля `tracks`, `composers` (как список артистов-композиторов),
+        `promotions`, `features` и `concerts`, однако эти поля не описаны в библиотеке:
+        `tracks`, `promotions`, `features` и `concerts` во всех опробованных метатегах возвращали
+        пустой список, из-за чего структура их элементов достоверно неизвестна. При необходимости
+        они могут быть добавлены в будущих версиях.
+
+    Attributes:
+        id (:obj:`str`, optional): Уникальный идентификатор метатега.
+        cover_uri (:obj:`str`, optional): Ссылка на обложку.
+        color (:obj:`str`, optional): Цвет оформления.
+        title (:obj:`yandex_music.MetatagTitle`, optional): Заголовок метатега.
+        liked (:obj:`bool`, optional): Отмечен ли метатег как понравившийся пользователем.
+        station_id (:obj:`str`, optional): Идентификатор радиостанции.
+        custom_wave_animation_url (:obj:`str`, optional): Ссылка на анимацию вайба.
+        artists (:obj:`list` из :obj:`yandex_music.Artist`): Список артистов метатега.
+        albums (:obj:`list` из :obj:`yandex_music.Album`): Список альбомов метатега.
+        playlists (:obj:`list` из :obj:`yandex_music.Playlist`): Список плейлистов метатега.
+        tracks_sort_by_values (:obj:`list` из :obj:`yandex_music.MetatagSortByValue`):
+            Допустимые значения сортировки списка треков.
+        albums_sort_by_values (:obj:`list` из :obj:`yandex_music.MetatagSortByValue`):
+            Допустимые значения сортировки списка альбомов.
+        playlists_sort_by_values (:obj:`list` из :obj:`yandex_music.MetatagSortByValue`):
+            Допустимые значения сортировки списка плейлистов.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    id: Optional[str] = None
+    cover_uri: Optional[str] = None
+    color: Optional[str] = None
+    title: Optional['MetatagTitle'] = None
+    liked: Optional[bool] = None
+    station_id: Optional[str] = None
+    custom_wave_animation_url: Optional[str] = None
+    artists: List['Artist'] = field(default_factory=list)
+    albums: List['Album'] = field(default_factory=list)
+    playlists: List['Playlist'] = field(default_factory=list)
+    tracks_sort_by_values: List['MetatagSortByValue'] = field(default_factory=list)
+    albums_sort_by_values: List['MetatagSortByValue'] = field(default_factory=list)
+    playlists_sort_by_values: List['MetatagSortByValue'] = field(default_factory=list)
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.id,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['Metatag']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.Metatag`: Метатег.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Album, Artist, MetatagSortByValue, MetatagTitle, Playlist
+
+        cls_data['title'] = MetatagTitle.de_json(cls_data.get('title'), client)
+        cls_data['artists'] = Artist.de_list(cls_data.get('artists'), client)
+        cls_data['albums'] = Album.de_list(cls_data.get('albums'), client)
+        cls_data['playlists'] = Playlist.de_list(cls_data.get('playlists'), client)
+        cls_data['tracks_sort_by_values'] = MetatagSortByValue.de_list(cls_data.get('tracks_sort_by_values'), client)
+        cls_data['albums_sort_by_values'] = MetatagSortByValue.de_list(cls_data.get('albums_sort_by_values'), client)
+        cls_data['playlists_sort_by_values'] = MetatagSortByValue.de_list(
+            cls_data.get('playlists_sort_by_values'), client
+        )
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/metatag/metatag_albums.py
+++ b/yandex_music/metatag/metatag_albums.py
@@ -1,0 +1,79 @@
+from dataclasses import field
+from typing import TYPE_CHECKING, Iterator, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import (
+        Album,
+        ClientType,
+        JSONType,
+        MetatagSortByValue,
+        MetatagTitle,
+        Pager,
+    )
+
+
+@model
+class MetatagAlbums(YandexMusicModel):
+    """Класс, представляющий страницу списка альбомов метатега.
+
+    Attributes:
+        id (:obj:`str`, optional): Уникальный идентификатор метатега.
+        cover_uri (:obj:`str`, optional): Ссылка на обложку.
+        color (:obj:`str`, optional): Цвет оформления.
+        title (:obj:`yandex_music.MetatagTitle`, optional): Заголовок метатега.
+        station_id (:obj:`str`, optional): Идентификатор радиостанции.
+        pager (:obj:`yandex_music.Pager`, optional): Пагинатор.
+        albums (:obj:`list` из :obj:`yandex_music.Album`): Альбомы метатега.
+        sort_by_values (:obj:`list` из :obj:`yandex_music.MetatagSortByValue`):
+            Допустимые значения сортировки.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    id: Optional[str] = None
+    cover_uri: Optional[str] = None
+    color: Optional[str] = None
+    title: Optional['MetatagTitle'] = None
+    station_id: Optional[str] = None
+    pager: Optional['Pager'] = None
+    albums: List['Album'] = field(default_factory=list)
+    sort_by_values: List['MetatagSortByValue'] = field(default_factory=list)
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.id, self.pager, self.albums)
+
+    def __getitem__(self, item: int) -> 'Album':
+        return self.albums[item]
+
+    def __iter__(self) -> Iterator['Album']:
+        return iter(self.albums)
+
+    def __len__(self) -> int:
+        return len(self.albums)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MetatagAlbums']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MetatagAlbums`: Страница списка альбомов метатега.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Album, MetatagSortByValue, MetatagTitle, Pager
+
+        cls_data['title'] = MetatagTitle.de_json(cls_data.get('title'), client)
+        cls_data['pager'] = Pager.de_json(cls_data.get('pager'), client)
+        cls_data['albums'] = Album.de_list(cls_data.get('albums'), client)
+        cls_data['sort_by_values'] = MetatagSortByValue.de_list(cls_data.get('sort_by_values'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/metatag/metatag_artist_entry.py
+++ b/yandex_music/metatag/metatag_artist_entry.py
@@ -1,0 +1,48 @@
+from dataclasses import field
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import Artist, ClientType, JSONType, Track
+
+
+@model
+class MetatagArtistEntry(YandexMusicModel):
+    """Класс, представляющий запись артиста в списке метатега.
+
+    Attributes:
+        artist (:obj:`yandex_music.Artist`, optional): Артист.
+        popular_tracks (:obj:`list` из :obj:`yandex_music.Track`): Популярные треки артиста.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    artist: Optional['Artist'] = None
+    popular_tracks: List['Track'] = field(default_factory=list)
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.artist,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MetatagArtistEntry']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MetatagArtistEntry`: Запись артиста в списке метатега.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import Artist, Track
+
+        cls_data['artist'] = Artist.de_json(cls_data.get('artist'), client)
+        cls_data['popular_tracks'] = Track.de_list(cls_data.get('popular_tracks'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/metatag/metatag_artists.py
+++ b/yandex_music/metatag/metatag_artists.py
@@ -1,0 +1,79 @@
+from dataclasses import field
+from typing import TYPE_CHECKING, Iterator, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import (
+        ClientType,
+        JSONType,
+        MetatagArtistEntry,
+        MetatagSortByValue,
+        MetatagTitle,
+        Pager,
+    )
+
+
+@model
+class MetatagArtists(YandexMusicModel):
+    """Класс, представляющий страницу списка артистов метатега.
+
+    Attributes:
+        id (:obj:`str`, optional): Уникальный идентификатор метатега.
+        cover_uri (:obj:`str`, optional): Ссылка на обложку.
+        color (:obj:`str`, optional): Цвет оформления.
+        title (:obj:`yandex_music.MetatagTitle`, optional): Заголовок метатега.
+        station_id (:obj:`str`, optional): Идентификатор радиостанции.
+        pager (:obj:`yandex_music.Pager`, optional): Пагинатор.
+        artists (:obj:`list` из :obj:`yandex_music.MetatagArtistEntry`): Артисты метатега с популярными треками.
+        sort_by_values (:obj:`list` из :obj:`yandex_music.MetatagSortByValue`):
+            Допустимые значения сортировки.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    id: Optional[str] = None
+    cover_uri: Optional[str] = None
+    color: Optional[str] = None
+    title: Optional['MetatagTitle'] = None
+    station_id: Optional[str] = None
+    pager: Optional['Pager'] = None
+    artists: List['MetatagArtistEntry'] = field(default_factory=list)
+    sort_by_values: List['MetatagSortByValue'] = field(default_factory=list)
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.id, self.pager, self.artists)
+
+    def __getitem__(self, item: int) -> 'MetatagArtistEntry':
+        return self.artists[item]
+
+    def __iter__(self) -> Iterator['MetatagArtistEntry']:
+        return iter(self.artists)
+
+    def __len__(self) -> int:
+        return len(self.artists)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MetatagArtists']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MetatagArtists`: Страница списка артистов метатега.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import MetatagArtistEntry, MetatagSortByValue, MetatagTitle, Pager
+
+        cls_data['title'] = MetatagTitle.de_json(cls_data.get('title'), client)
+        cls_data['pager'] = Pager.de_json(cls_data.get('pager'), client)
+        cls_data['artists'] = MetatagArtistEntry.de_list(cls_data.get('artists'), client)
+        cls_data['sort_by_values'] = MetatagSortByValue.de_list(cls_data.get('sort_by_values'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/metatag/metatag_leaf.py
+++ b/yandex_music/metatag/metatag_leaf.py
@@ -1,0 +1,50 @@
+from dataclasses import field
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+
+
+@model
+class MetatagLeaf(YandexMusicModel):
+    """Класс, представляющий лист дерева метатегов.
+
+    Значение поля :attr:`tag` используется как идентификатор метатега в запросах
+    к ручкам :attr:`yandex_music.Client.metatag` и родственных методов.
+
+    Attributes:
+        tag (:obj:`str`, optional): Идентификатор метатега.
+        title (:obj:`str`, optional): Название метатега для отображения.
+        leaves (:obj:`list` из :obj:`yandex_music.MetatagLeaf`, optional): Вложенные листы метатега.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    tag: Optional[str] = None
+    title: Optional[str] = None
+    leaves: List['MetatagLeaf'] = field(default_factory=list)
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.tag,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MetatagLeaf']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MetatagLeaf`: Лист дерева метатегов.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        cls_data['leaves'] = MetatagLeaf.de_list(cls_data.get('leaves'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/metatag/metatag_playlists.py
+++ b/yandex_music/metatag/metatag_playlists.py
@@ -1,0 +1,79 @@
+from dataclasses import field
+from typing import TYPE_CHECKING, Iterator, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import (
+        ClientType,
+        JSONType,
+        MetatagSortByValue,
+        MetatagTitle,
+        Pager,
+        Playlist,
+    )
+
+
+@model
+class MetatagPlaylists(YandexMusicModel):
+    """Класс, представляющий страницу списка плейлистов метатега.
+
+    Attributes:
+        id (:obj:`str`, optional): Уникальный идентификатор метатега.
+        cover_uri (:obj:`str`, optional): Ссылка на обложку.
+        color (:obj:`str`, optional): Цвет оформления.
+        title (:obj:`yandex_music.MetatagTitle`, optional): Заголовок метатега.
+        station_id (:obj:`str`, optional): Идентификатор радиостанции.
+        pager (:obj:`yandex_music.Pager`, optional): Пагинатор.
+        playlists (:obj:`list` из :obj:`yandex_music.Playlist`): Плейлисты метатега.
+        sort_by_values (:obj:`list` из :obj:`yandex_music.MetatagSortByValue`):
+            Допустимые значения сортировки.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    id: Optional[str] = None
+    cover_uri: Optional[str] = None
+    color: Optional[str] = None
+    title: Optional['MetatagTitle'] = None
+    station_id: Optional[str] = None
+    pager: Optional['Pager'] = None
+    playlists: List['Playlist'] = field(default_factory=list)
+    sort_by_values: List['MetatagSortByValue'] = field(default_factory=list)
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.id, self.pager, self.playlists)
+
+    def __getitem__(self, item: int) -> 'Playlist':
+        return self.playlists[item]
+
+    def __iter__(self) -> Iterator['Playlist']:
+        return iter(self.playlists)
+
+    def __len__(self) -> int:
+        return len(self.playlists)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MetatagPlaylists']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MetatagPlaylists`: Страница списка плейлистов метатега.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import MetatagSortByValue, MetatagTitle, Pager, Playlist
+
+        cls_data['title'] = MetatagTitle.de_json(cls_data.get('title'), client)
+        cls_data['pager'] = Pager.de_json(cls_data.get('pager'), client)
+        cls_data['playlists'] = Playlist.de_list(cls_data.get('playlists'), client)
+        cls_data['sort_by_values'] = MetatagSortByValue.de_list(cls_data.get('sort_by_values'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/metatag/metatag_sort_by_value.py
+++ b/yandex_music/metatag/metatag_sort_by_value.py
@@ -1,0 +1,30 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class MetatagSortByValue(YandexMusicModel):
+    """Класс, представляющий доступное значение сортировки списка метатега.
+
+    Note:
+        Известные значения поля `value`: `popular`, `new`.
+
+    Attributes:
+        value (:obj:`str`, optional): Идентификатор значения сортировки.
+        title (:obj:`str`, optional): Отображаемое название сортировки.
+        active (:obj:`bool`, optional): Применена ли эта сортировка в текущем ответе.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    value: Optional[str] = None
+    title: Optional[str] = None
+    active: Optional[bool] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.value, self.active)

--- a/yandex_music/metatag/metatag_title.py
+++ b/yandex_music/metatag/metatag_title.py
@@ -1,0 +1,25 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType
+
+
+@model
+class MetatagTitle(YandexMusicModel):
+    """Класс, представляющий заголовок метатега.
+
+    Attributes:
+        title (:obj:`str`, optional): Короткий заголовок.
+        full_title (:obj:`str`, optional): Полный заголовок.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    title: Optional[str] = None
+    full_title: Optional[str] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.title, self.full_title)

--- a/yandex_music/metatag/metatag_tree.py
+++ b/yandex_music/metatag/metatag_tree.py
@@ -1,0 +1,52 @@
+from dataclasses import field
+from typing import TYPE_CHECKING, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType, MetatagLeaf
+
+
+@model
+class MetatagTree(YandexMusicModel):
+    """Класс, представляющий раздел дерева метатегов.
+
+    Note:
+        Известные значения поля `navigation_id`: `moods`, `activities`, `genres`, `epochs`.
+
+    Attributes:
+        title (:obj:`str`, optional): Название раздела.
+        navigation_id (:obj:`str`, optional): Идентификатор раздела навигации.
+        leaves (:obj:`list` из :obj:`yandex_music.MetatagLeaf`): Листы раздела с метатегами.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    title: Optional[str] = None
+    navigation_id: Optional[str] = None
+    leaves: List['MetatagLeaf'] = field(default_factory=list)
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.navigation_id, self.title)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['MetatagTree']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.MetatagTree`: Раздел дерева метатегов.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import MetatagLeaf
+
+        cls_data['leaves'] = MetatagLeaf.de_list(cls_data.get('leaves'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/metatag/metatags.py
+++ b/yandex_music/metatag/metatags.py
@@ -1,0 +1,54 @@
+from dataclasses import field
+from typing import TYPE_CHECKING, Iterator, List, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType, MetatagTree
+
+
+@model
+class Metatags(YandexMusicModel):
+    """Класс, представляющий дерево метатегов.
+
+    Attributes:
+        trees (:obj:`list` из :obj:`yandex_music.MetatagTree`): Разделы дерева метатегов.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    trees: List['MetatagTree'] = field(default_factory=list)
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.trees,)
+
+    def __getitem__(self, item: int) -> 'MetatagTree':
+        return self.trees[item]
+
+    def __iter__(self) -> Iterator['MetatagTree']:
+        return iter(self.trees)
+
+    def __len__(self) -> int:
+        return len(self.trees)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['Metatags']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.Metatags`: Дерево метатегов.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import MetatagTree
+
+        cls_data['trees'] = MetatagTree.de_list(cls_data.get('trees'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/track/track.py
+++ b/yandex_music/track/track.py
@@ -100,6 +100,8 @@ class Track(YandexMusicModel):
         smart_preview_params (:obj:`yandex_music.SmartPreviewParams`, optional): Параметры умного превью трека.
         special_audio_resources (:obj:`list` из :obj:`str`, optional): Специальные аудиоресурсы.
         disclaimers (:obj:`list` из :obj:`str`, optional): Список дисклеймеров.
+        background_video_id (:obj:`str`, optional): Уникальный идентификатор видеошота.
+        player_id (:obj:`str`, optional): Идентификатор плеера видеошота.
         client (:obj:`yandex_music.Client`): Клиент Yandex Music.
     """
 
@@ -151,6 +153,8 @@ class Track(YandexMusicModel):
     smart_preview_params: Optional['SmartPreviewParams'] = None
     special_audio_resources: Optional[List[str]] = None
     disclaimers: Optional[List[str]] = None
+    background_video_id: Optional[str] = None
+    player_id: Optional[str] = None
     client: Optional['ClientType'] = None
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
Новый миксин MetatagsMixin (metatags.py):
- metatags — GET /landing3/metatags
- metatag — GET /metatags/:id
- metatag_albums — GET /metatags/:id/albums
- metatag_artists — GET /metatags/:id/artists
- metatag_playlists — GET /metatags/:id/playlists

Новые модели (yandex_music/metatag/):
- Metatag, Metatags, MetatagTree, MetatagLeaf, MetatagTitle, MetatagSortByValue, MetatagAlbums, MetatagArtists, MetatagArtistEntry, MetatagPlaylists

Новые поля:
- Track: background_video_id, player_id

Примечания:
- Поля tracks, composers, promotions, features, concerts в ответе /metatags/:id во всех опробованных метатегах возвращали пустой список, поэтому не смоделированы. Ограничение задокументировано в docstring Metatag и Client.metatag.
- Параметр period обязателен для /metatags/:id/artists (без него API возвращает ошибку валидации).
- MetatagLeaf поддерживает рекурсивную вложенность через поле leaves.