### PR TITLE
Добавлен маршрут детальных экспериментов аккаунта и новые модели

### DIFF
--- a/docs/source/yandex_music.experiment.experiment_detail.rst
+++ b/docs/source/yandex_music.experiment.experiment_detail.rst
@@ -1,0 +1,7 @@
+yandex\_music.experiment.experiment\_detail
+===========================================
+
+.. automodule:: yandex_music.experiment.experiment_detail
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.experiment.experiment_detail_value.rst
+++ b/docs/source/yandex_music.experiment.experiment_detail_value.rst
@@ -1,0 +1,7 @@
+yandex\_music.experiment.experiment\_detail\_value
+==================================================
+
+.. automodule:: yandex_music.experiment.experiment_detail_value
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.experiment.experiments_details.rst
+++ b/docs/source/yandex_music.experiment.experiments_details.rst
@@ -1,0 +1,7 @@
+yandex\_music.experiment.experiments\_details
+=============================================
+
+.. automodule:: yandex_music.experiment.experiments_details
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/yandex_music.experiment.rst
+++ b/docs/source/yandex_music.experiment.rst
@@ -1,0 +1,17 @@
+yandex\_music.experiment
+========================
+
+.. automodule:: yandex_music.experiment
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   yandex_music.experiment.experiment_detail
+   yandex_music.experiment.experiment_detail_value
+   yandex_music.experiment.experiments_details

--- a/docs/source/yandex_music.rst
+++ b/docs/source/yandex_music.rst
@@ -17,6 +17,7 @@ Subpackages
    yandex_music.artist
    yandex_music.clip
    yandex_music.concert
+   yandex_music.experiment
    yandex_music.feed
    yandex_music.genre
    yandex_music.label

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -69,6 +69,9 @@ from .test_disclaimer import TestDisclaimer
 from .test_discrete_scale import TestDiscreteScale
 from .test_enum import TestEnum
 from .test_event import TestEvent
+from .test_experiment_detail import TestExperimentDetail
+from .test_experiment_detail_value import TestExperimentDetailValue
+from .test_experiments_details import TestExperimentsDetails
 from .test_fade import TestFade
 from .test_foreign_agent import TestForeignAgent
 from .test_generated_playlist import TestGeneratedPlaylist

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,9 @@ from yandex_music import (
     DiscreteScale,
     Enum,
     Event,
+    ExperimentDetail,
+    ExperimentDetailValue,
+    ExperimentsDetails,
     Fade,
     ForeignAgent,
     GeneratedPlaylist,
@@ -237,6 +240,8 @@ from . import (
     TestDiscreteScale,
     TestEnum,
     TestEvent,
+    TestExperimentDetail,
+    TestExperimentDetailValue,
     TestFade,
     TestForeignAgent,
     TestGeneratedPlaylist,
@@ -1819,6 +1824,24 @@ def disclaimer(foreign_agent):
     return Disclaimer(
         foreign_agent=foreign_agent,
     )
+
+
+@pytest.fixture(scope='session')
+def experiment_detail_value():
+    value = ExperimentDetailValue(title=TestExperimentDetailValue.title)
+    value.__dict__['enabled'] = TestExperimentDetailValue.enabled
+    value.__dict__['delay'] = TestExperimentDetailValue.delay
+    return value
+
+
+@pytest.fixture(scope='session')
+def experiment_detail(experiment_detail_value):
+    return ExperimentDetail(group=TestExperimentDetail.group, value=experiment_detail_value)
+
+
+@pytest.fixture(scope='session')
+def experiments_details(experiment_detail):
+    return ExperimentsDetails(experiments={'TestExperiment': experiment_detail})
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_experiment_detail.py
+++ b/tests/test_experiment_detail.py
@@ -1,0 +1,37 @@
+from yandex_music import ExperimentDetail
+
+
+class TestExperimentDetail:
+    group = 'test_group'
+
+    def test_expected_values(self, experiment_detail, experiment_detail_value):
+        assert experiment_detail.group == self.group
+        assert experiment_detail.value == experiment_detail_value
+
+    def test_de_json_none(self, client):
+        assert ExperimentDetail.de_json({}, client) is None
+
+    def test_de_json_required(self, client):
+        json_dict = {'group': self.group}
+        detail = ExperimentDetail.de_json(json_dict, client)
+
+        assert detail.group == self.group
+        assert detail.value is None
+
+    def test_de_json_all(self, client, experiment_detail_value):
+        json_dict = {'group': self.group, 'value': experiment_detail_value.to_dict()}
+        detail = ExperimentDetail.de_json(json_dict, client)
+
+        assert detail.group == self.group
+        assert detail.value == experiment_detail_value
+
+    def test_equality(self, experiment_detail_value):
+        a = ExperimentDetail(group=self.group, value=experiment_detail_value)
+        b = ExperimentDetail(group='other_group', value=experiment_detail_value)
+        c = ExperimentDetail(group=self.group, value=experiment_detail_value)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_experiment_detail_value.py
+++ b/tests/test_experiment_detail_value.py
@@ -1,0 +1,53 @@
+from yandex_music import ExperimentDetailValue
+
+
+class TestExperimentDetailValue:
+    title = 'test_group'
+    enabled = True
+    delay = 42
+
+    def test_expected_values(self, experiment_detail_value):
+        assert experiment_detail_value.title == self.title
+        assert experiment_detail_value.enabled == self.enabled
+        assert experiment_detail_value.delay == self.delay
+
+    def test_de_json_none(self, client):
+        assert ExperimentDetailValue.de_json({}, client) is None
+
+    def test_de_json_required(self, client):
+        json_dict = {'title': self.title}
+        value = ExperimentDetailValue.de_json(json_dict, client)
+
+        assert value.title == self.title
+
+    def test_de_json_all(self, client):
+        json_dict = {
+            'title': self.title,
+            'enabled': self.enabled,
+            'delay': self.delay,
+            'trackSkipTimeoutSec': 15,
+        }
+        value = ExperimentDetailValue.de_json(json_dict, client)
+
+        assert value.title == self.title
+        assert value.enabled == self.enabled
+        assert value.delay == self.delay
+        # camelCase ключ нормализуется в snake_case
+        assert value.track_skip_timeout_sec == 15
+
+    def test_de_json_title_non_string(self, client):
+        json_dict = {'title': 123}
+        value = ExperimentDetailValue.de_json(json_dict, client)
+
+        assert value.title is None
+
+    def test_equality(self):
+        a = ExperimentDetailValue(title=self.title)
+        b = ExperimentDetailValue(title='other_group')
+        c = ExperimentDetailValue(title=self.title)
+
+        assert a != b
+        assert hash(a) != hash(b)
+        assert a is not b
+
+        assert a == c

--- a/tests/test_experiments_details.py
+++ b/tests/test_experiments_details.py
@@ -1,0 +1,33 @@
+from yandex_music import ExperimentsDetails
+
+
+class TestExperimentsDetails:
+    def test_expected_values(self, experiments_details, experiment_detail):
+        assert experiments_details.experiments == {'TestExperiment': experiment_detail}
+
+    def test_de_json_none(self, client):
+        assert ExperimentsDetails.de_json({}, client) is None
+
+    def test_de_json_all(self, client, experiment_detail):
+        json_dict = {'TestExperiment': experiment_detail.to_dict()}
+        details = ExperimentsDetails.de_json(json_dict, client)
+
+        assert 'TestExperiment' in details.experiments
+        assert details.experiments['TestExperiment'] == experiment_detail
+
+    def test_de_json_preserves_original_keys(self, client, experiment_detail):
+        # Ключи экспериментов сохраняются как есть (CamelCase, с цифрами и т. п.)
+        json_dict = {
+            'AliceTest': experiment_detail.to_dict(),
+            '3dsRubilnik': experiment_detail.to_dict(),
+        }
+        details = ExperimentsDetails.de_json(json_dict, client)
+
+        assert set(details.experiments.keys()) == {'AliceTest', '3dsRubilnik'}
+
+    def test_de_json_skips_non_dict_entries(self, client, experiment_detail):
+        json_dict = {'Good': experiment_detail.to_dict(), 'Bad': 'not-a-dict'}
+        details = ExperimentsDetails.de_json(json_dict, client)
+
+        assert 'Good' in details.experiments
+        assert 'Bad' not in details.experiments

--- a/yandex_music/__init__.py
+++ b/yandex_music/__init__.py
@@ -7,6 +7,9 @@ from .base import ClientType, YandexMusicObject, YandexMusicModel, JSONType, Map
 from .settings import Settings
 from .permission_alerts import PermissionAlerts
 from .experiments import Experiments
+from .experiment.experiment_detail_value import ExperimentDetailValue
+from .experiment.experiment_detail import ExperimentDetail
+from .experiment.experiments_details import ExperimentsDetails
 
 from .account.status import Status
 from .account.account import Account
@@ -318,7 +321,10 @@ __all__ = [
     'DownloadInfo',
     'Enum',
     'Event',
+    'ExperimentDetail',
+    'ExperimentDetailValue',
     'Experiments',
+    'ExperimentsDetails',
     'Fade',
     'Feed',
     'ForeignAgent',

--- a/yandex_music/_client/account.py
+++ b/yandex_music/_client/account.py
@@ -6,7 +6,15 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from typing_extensions import Self
 
-from yandex_music import Experiments, PermissionAlerts, PromoCodeStatus, Settings, Status, UserSettings
+from yandex_music import (
+    Experiments,
+    ExperimentsDetails,
+    PermissionAlerts,
+    PromoCodeStatus,
+    Settings,
+    Status,
+    UserSettings,
+)
 from yandex_music._client import log
 from yandex_music._client_base import ClientBase
 
@@ -180,6 +188,31 @@ class AccountMixin(ClientBase):
         return Experiments.de_json(result, self)
 
     @log
+    def account_experiments_details(self, *args: Any, **kwargs: Any) -> Optional[ExperimentsDetails]:
+        """Получение детальной информации об экспериментальных функциях аккаунта.
+
+        Note:
+            В отличие от :meth:`account_experiments`, в ответе для каждого эксперимента
+            возвращается не только выбранная группа, но и её параметры конфигурации.
+
+        Args:
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.ExperimentsDetails` | :obj:`None`: Детальные значения
+                экспериментов или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/account/experiments/details'
+
+        result = self._request.get(url, *args, **kwargs)
+
+        return ExperimentsDetails.de_json(result, self)
+
+    @log
     def consume_promo_code(
         self, code: str, language: Optional[str] = None, *args, **kwargs
     ) -> Optional[PromoCodeStatus]:
@@ -221,5 +254,7 @@ class AccountMixin(ClientBase):
     permissionAlerts = permission_alerts
     #: Псевдоним для :attr:`account_experiments`
     accountExperiments = account_experiments
+    #: Псевдоним для :attr:`account_experiments_details`
+    accountExperimentsDetails = account_experiments_details
     #: Псевдоним для :attr:`consume_promo_code`
     consumePromoCode = consume_promo_code

--- a/yandex_music/_client_async/account.py
+++ b/yandex_music/_client_async/account.py
@@ -2,7 +2,15 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from typing_extensions import Self
 
-from yandex_music import Experiments, PermissionAlerts, PromoCodeStatus, Settings, Status, UserSettings
+from yandex_music import (
+    Experiments,
+    ExperimentsDetails,
+    PermissionAlerts,
+    PromoCodeStatus,
+    Settings,
+    Status,
+    UserSettings,
+)
 from yandex_music._client_async import log
 from yandex_music._client_base import ClientBase
 
@@ -176,6 +184,31 @@ class AccountMixin(ClientBase):
         return Experiments.de_json(result, self)
 
     @log
+    async def account_experiments_details(self, *args: Any, **kwargs: Any) -> Optional[ExperimentsDetails]:
+        """Получение детальной информации об экспериментальных функциях аккаунта.
+
+        Note:
+            В отличие от :meth:`account_experiments`, в ответе для каждого эксперимента
+            возвращается не только выбранная группа, но и её параметры конфигурации.
+
+        Args:
+            *args: Произвольные аргументы (будут переданы в запрос).
+            **kwargs: Произвольные именованные аргументы (будут переданы в запрос).
+
+        Returns:
+            :obj:`yandex_music.ExperimentsDetails` | :obj:`None`: Детальные значения
+                экспериментов или :obj:`None`.
+
+        Raises:
+            :class:`yandex_music.exceptions.YandexMusicError`: Базовое исключение библиотеки.
+        """
+        url = f'{self.base_url}/account/experiments/details'
+
+        result = await self._request.get(url, *args, **kwargs)
+
+        return ExperimentsDetails.de_json(result, self)
+
+    @log
     async def consume_promo_code(
         self, code: str, language: Optional[str] = None, *args, **kwargs
     ) -> Optional[PromoCodeStatus]:
@@ -217,5 +250,7 @@ class AccountMixin(ClientBase):
     permissionAlerts = permission_alerts
     #: Псевдоним для :attr:`account_experiments`
     accountExperiments = account_experiments
+    #: Псевдоним для :attr:`account_experiments_details`
+    accountExperimentsDetails = account_experiments_details
     #: Псевдоним для :attr:`consume_promo_code`
     consumePromoCode = consume_promo_code

--- a/yandex_music/experiment/experiment_detail.py
+++ b/yandex_music/experiment/experiment_detail.py
@@ -1,0 +1,52 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, ExperimentDetailValue, JSONType
+
+
+@model
+class ExperimentDetail(YandexMusicModel):
+    """Класс, представляющий один эксперимент в детализированном ответе.
+
+    Note:
+        Значение поля :attr:`group` совпадает с :attr:`value.title
+        <yandex_music.ExperimentDetailValue.title>`. Поле :attr:`value`
+        содержит дополнительные параметры конфигурации выбранной группы эксперимента.
+
+    Attributes:
+        group (:obj:`str`, optional): Название выбранной группы эксперимента.
+        value (:obj:`yandex_music.ExperimentDetailValue`, optional): Конфигурация
+            выбранной группы эксперимента.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    group: Optional[str] = None
+    value: Optional['ExperimentDetailValue'] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.group, self.value)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['ExperimentDetail']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.ExperimentDetail`: Описание эксперимента.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        cls_data = cls.cleanup_data(data, client)
+        from yandex_music import ExperimentDetailValue
+
+        cls_data['value'] = ExperimentDetailValue.de_json(cls_data.get('value'), client)
+
+        return cls(client=client, **cls_data)

--- a/yandex_music/experiment/experiment_detail_value.py
+++ b/yandex_music/experiment/experiment_detail_value.py
@@ -1,0 +1,60 @@
+from typing import TYPE_CHECKING, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+from yandex_music.utils.normalize import _normalize_key
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, JSONType
+
+
+@model
+class ExperimentDetailValue(YandexMusicModel):
+    """Класс, представляющий значение (конфигурацию) эксперимента.
+
+    Note:
+        Для каждого эксперимента API возвращает свой набор полей конфигурации:
+        флаги, идентификаторы, пороговые значения, списки, вложенные словари и т. п.
+        Универсальное поле у всех экспериментов одно — :attr:`title`; оно совпадает
+        с :attr:`yandex_music.ExperimentDetail.group`.
+
+        Остальные поля сохраняются в :obj:`__dict__` экземпляра при десериализации
+        и доступны как обычные атрибуты и через :meth:`to_dict`. Их набор и типы
+        зависят от конкретного эксперимента и не типизируются.
+
+    Attributes:
+        title (:obj:`str`, optional): Название/идентификатор группы эксперимента.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    title: Optional[str] = None
+    client: Optional['ClientType'] = None
+
+    def __post_init__(self) -> None:
+        self._id_attrs = (self.title,)
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['ExperimentDetailValue']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.ExperimentDetailValue`: Значение эксперимента.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        raw_title = data.get('title')
+        title = raw_title if isinstance(raw_title, str) else None
+        instance = cls(client=client, title=title)
+
+        for key, value in data.items():
+            normalized = _normalize_key(key)
+            if normalized in ('title', 'client'):
+                continue
+            instance.__dict__[normalized] = value
+
+        return instance

--- a/yandex_music/experiment/experiments_details.py
+++ b/yandex_music/experiment/experiments_details.py
@@ -1,0 +1,53 @@
+from dataclasses import field
+from typing import TYPE_CHECKING, Dict, Optional
+
+from yandex_music import YandexMusicModel
+from yandex_music.utils import model
+
+if TYPE_CHECKING:
+    from yandex_music import ClientType, ExperimentDetail, JSONType
+
+
+@model
+class ExperimentsDetails(YandexMusicModel):
+    """Класс, представляющий детальные значения экспериментальных функций аккаунта.
+
+    Note:
+        API возвращает словарь, где ключи — названия экспериментов (например,
+        ``AliceTest`` или ``3dsRubilnik``), а значения — объекты
+        :class:`yandex_music.ExperimentDetail` с названием выбранной группы и её
+        параметрами. Набор экспериментов заранее неизвестен и может меняться от
+        запроса к запросу, поэтому хранится в :attr:`experiments`.
+
+    Attributes:
+        experiments (:obj:`dict` из :obj:`str` в :obj:`yandex_music.ExperimentDetail`):
+            Словарь экспериментов, ключ — название эксперимента.
+        client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+    """
+
+    experiments: Dict[str, 'ExperimentDetail'] = field(default_factory=dict)
+    client: Optional['ClientType'] = None
+
+    @classmethod
+    def de_json(cls, data: 'JSONType', client: 'ClientType') -> Optional['ExperimentsDetails']:
+        """Десериализация объекта.
+
+        Args:
+            data (:obj:`dict`): Поля и значения десериализуемого объекта.
+            client (:obj:`yandex_music.Client`, optional): Клиент Yandex Music.
+
+        Returns:
+            :obj:`yandex_music.ExperimentsDetails`: Детали экспериментов аккаунта.
+        """
+        if not cls.is_dict_model_data(data):
+            return None
+
+        from yandex_music import ExperimentDetail
+
+        experiments: Dict[str, 'ExperimentDetail'] = {}
+        for name, entry in data.items():
+            detail = ExperimentDetail.de_json(entry, client)
+            if detail is not None:
+                experiments[name] = detail
+
+        return cls(client=client, experiments=experiments)


### PR DESCRIPTION
Расширенный миксин AccountMixin (account.py):
- account_experiments_details — GET /account/experiments/details

Новые модели (yandex_music/experiment/):
- ExperimentDetailValue — значение (конфигурация) эксперимента; универсальное поле `title`, остальные per-experiment поля (более 150 различных возможных ключей в ответе) сохраняются в __dict__ и доступны как атрибуты
- ExperimentDetail — пара group + value для одного эксперимента
- ExperimentsDetails — словарь экспериментов, ключ — произвольное название эксперимента (например, `AliceTest` или `3dsRubilnik`)

Маршруты acceptInvite (POST /account/family/accept-invite/:inviteId) и getInviteInfo (GET /account/family/invite-info/:inviteId) требуют реального family-invite ID и пока отложены.